### PR TITLE
fix: rod_press key handling - parse string keys correctly

### DIFF
--- a/tools/common.go
+++ b/tools/common.go
@@ -21,6 +21,81 @@ const (
 	defaultDomDiff       = 0.2
 )
 
+// keyMap maps string key names to input.Key constants.
+// Supports both named keys (Tab, Enter, ArrowUp) and single characters.
+var keyMap = map[string]input.Key{
+	// Function keys
+	"Escape": input.Escape,
+	"F1":     input.F1,
+	"F2":     input.F2,
+	"F3":     input.F3,
+	"F4":     input.F4,
+	"F5":     input.F5,
+	"F6":     input.F6,
+	"F7":     input.F7,
+	"F8":     input.F8,
+	"F9":     input.F9,
+	"F10":    input.F10,
+	"F11":    input.F11,
+	"F12":    input.F12,
+
+	// Navigation
+	"Backspace":  input.Backspace,
+	"Tab":        input.Tab,
+	"Enter":      input.Enter,
+	"Return":     input.Enter,
+	"CapsLock":   input.CapsLock,
+	"Delete":     input.Delete,
+	"End":        input.End,
+	"Home":       input.Home,
+	"Insert":     input.Insert,
+	"PageDown":   input.PageDown,
+	"PageUp":     input.PageUp,
+	"ArrowDown":  input.ArrowDown,
+	"ArrowLeft":  input.ArrowLeft,
+	"ArrowRight": input.ArrowRight,
+	"ArrowUp":    input.ArrowUp,
+
+	// Modifiers
+	"Alt":        input.AltLeft,
+	"AltLeft":    input.AltLeft,
+	"AltRight":   input.AltRight,
+	"Control":    input.ControlLeft,
+	"ControlLeft": input.ControlLeft,
+	"ControlRight": input.ControlRight,
+	"Meta":       input.MetaLeft,
+	"MetaLeft":   input.MetaLeft,
+	"MetaRight":  input.MetaRight,
+	"Shift":      input.ShiftLeft,
+	"ShiftLeft":  input.ShiftLeft,
+	"ShiftRight": input.ShiftRight,
+
+	// Special keys
+	"Space":       input.Space,
+	"PrintScreen": input.PrintScreen,
+	"ScrollLock":  input.ScrollLock,
+	"Pause":       input.Pause,
+	"ContextMenu": input.ContextMenu,
+	"NumLock":     input.NumLock,
+}
+
+// parseKey converts a key string to an input.Key.
+// For single characters, returns the rune as input.Key.
+// For named keys (Tab, Enter, ArrowUp, etc.), looks up in keyMap.
+func parseKey(keyStr string) (input.Key, error) {
+	// Check if it's a named key first
+	if key, ok := keyMap[keyStr]; ok {
+		return key, nil
+	}
+
+	// For single characters, use the rune value directly
+	if len(keyStr) == 1 {
+		return input.Key(keyStr[0]), nil
+	}
+
+	return 0, fmt.Errorf("unknown key: %s", keyStr)
+}
+
 const (
 	NavigationToolKey   = "rod_navigate"
 	GoBackToolKey       = "rod_go_back"
@@ -169,14 +244,19 @@ var (
 				log.Errorf("Failed to press key: %s", err.Error())
 				return nil, errors.New(fmt.Sprintf("Failed to press key: %s", err.Error()))
 			}
-			key := request.Params.Arguments["key"].(rune)
-			err = page.Keyboard.Type(input.Key(key))
+			keyStr := request.Params.Arguments["key"].(string)
+			key, err := parseKey(keyStr)
 			if err != nil {
-				log.Errorf("Failed to press key %s: %s", string(key), err.Error())
-				return nil, errors.New(fmt.Sprintf("Failed to press key %s: %s", string(key), err.Error()))
+				log.Errorf("Failed to parse key %s: %s", keyStr, err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to parse key %s: %s", keyStr, err.Error()))
+			}
+			err = page.Keyboard.Press(key)
+			if err != nil {
+				log.Errorf("Failed to press key %s: %s", keyStr, err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to press key %s: %s", keyStr, err.Error()))
 			}
 			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
-			return mcp.NewToolResultText(fmt.Sprintf("Press key %s successfully", string(key))), nil
+			return mcp.NewToolResultText(fmt.Sprintf("Press key %s successfully", keyStr)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: rodCtx.CurrentMode() == types.Text})
 	}

--- a/tools/common_test.go
+++ b/tools/common_test.go
@@ -1,0 +1,64 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/go-rod/rod/lib/input"
+)
+
+func TestParseKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		keyStr  string
+		want    input.Key
+		wantErr bool
+	}{
+		// Named keys
+		{"Tab", "Tab", input.Tab, false},
+		{"Enter", "Enter", input.Enter, false},
+		{"Return alias", "Return", input.Enter, false},
+		{"Escape", "Escape", input.Escape, false},
+		{"Backspace", "Backspace", input.Backspace, false},
+		{"Delete", "Delete", input.Delete, false},
+		{"Space", "Space", input.Space, false},
+
+		// Arrow keys
+		{"ArrowUp", "ArrowUp", input.ArrowUp, false},
+		{"ArrowDown", "ArrowDown", input.ArrowDown, false},
+		{"ArrowLeft", "ArrowLeft", input.ArrowLeft, false},
+		{"ArrowRight", "ArrowRight", input.ArrowRight, false},
+
+		// Function keys
+		{"F1", "F1", input.F1, false},
+		{"F12", "F12", input.F12, false},
+
+		// Modifiers
+		{"Shift", "Shift", input.ShiftLeft, false},
+		{"Control", "Control", input.ControlLeft, false},
+		{"Alt", "Alt", input.AltLeft, false},
+		{"Meta", "Meta", input.MetaLeft, false},
+
+		// Single characters
+		{"lowercase a", "a", input.Key('a'), false},
+		{"uppercase A", "A", input.Key('A'), false},
+		{"digit 1", "1", input.Key('1'), false},
+		{"special char @", "@", input.Key('@'), false},
+
+		// Errors
+		{"unknown key", "UnknownKey", 0, true},
+		{"multi-char non-key", "abc", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseKey(tt.keyStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseKey(%q) error = %v, wantErr %v", tt.keyStr, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseKey(%q) = %v, want %v", tt.keyStr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix rod_press tool that was causing MCP error -32000 (Connection closed) when pressing special keys like Tab, ArrowDown, Enter
- Add proper key string parsing with support for named keys and single characters
- Add comprehensive test coverage for the parseKey function

## Root Cause

The `PressKeyHandler` was incorrectly type-asserting the key argument directly to `rune`:

```go
key := request.Params.Arguments["key"].(rune)  // WRONG - MCP sends strings!
```

When MCP sent a string like "Tab", this type assertion panicked, closing the connection.

## Solution

1. **Parse key string correctly**: Extract the key as a string, then map it to the appropriate `input.Key` constant
2. **Key mapping**: Added a comprehensive `keyMap` supporting:
   - Function keys (F1-F12)
   - Navigation keys (Tab, Enter, Backspace, Delete, Home, End, PageUp, PageDown)
   - Arrow keys (ArrowUp, ArrowDown, ArrowLeft, ArrowRight)
   - Modifier keys (Shift, Control, Alt, Meta)
   - Special keys (Escape, Space, PrintScreen, etc.)
   - Single characters (a-z, A-Z, 0-9, symbols)
3. **Use Keyboard.Press()**: Changed from `Keyboard.Type()` to `Keyboard.Press()` for proper key event handling

## Test plan

- [x] Build passes: `go build ./...`
- [x] All tests pass: `go test ./...`
- [x] Added unit tests for `parseKey` function covering named keys, single chars, and error cases
- [ ] Manual test: `rod_press` with key="Tab" should work without connection closure
- [ ] Manual test: `rod_press` with key="ArrowDown" should navigate dropdowns correctly

Fixes #6
Fixes #4