### PR TITLE
refactor: quick-win cleanups (#21, #22, #25, #26, #29)

### DIFF
--- a/resources/console.go
+++ b/resources/console.go
@@ -1,9 +1,0 @@
-package resources
-
-import "github.com/mark3labs/mcp-go/mcp"
-
-var Console = mcp.NewResource(
-	"rod://console",
-	"Page console",
-	mcp.WithMIMEType("text/plain"),
-)

--- a/resources/network.go
+++ b/resources/network.go
@@ -1,9 +1,0 @@
-package resources
-
-import "github.com/mark3labs/mcp-go/mcp"
-
-var Network = mcp.NewResource(
-	"rod://network",
-	"Page network",
-	mcp.WithMIMEType("text/plain"),
-)

--- a/tools/common.go
+++ b/tools/common.go
@@ -179,7 +179,7 @@ var (
 			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
 			return mcp.NewToolResultText(fmt.Sprintf("Navigated to %s", url)), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: rodCtx.CurrentMode() == types.Text})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: rodCtx.CurrentMode() == types.Text})
 	}
 
 	GoBackHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
@@ -197,7 +197,7 @@ var (
 			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
 			return mcp.NewToolResultText("Go back successfully"), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: rodCtx.CurrentMode() == types.Text})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: rodCtx.CurrentMode() == types.Text})
 	}
 
 	GoForwardHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
@@ -215,7 +215,7 @@ var (
 			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
 			return mcp.NewToolResultText("Go forward successfully"), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: rodCtx.CurrentMode() == types.Text})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: rodCtx.CurrentMode() == types.Text})
 	}
 
 	ReLoadHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
@@ -233,7 +233,7 @@ var (
 			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
 			return mcp.NewToolResultText("Reload current page successfully"), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: rodCtx.CurrentMode() == types.Text})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: rodCtx.CurrentMode() == types.Text})
 	}
 
 	PressKeyHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
@@ -257,7 +257,7 @@ var (
 			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
 			return mcp.NewToolResultText(fmt.Sprintf("Press key %s successfully", keyStr)), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: rodCtx.CurrentMode() == types.Text})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: rodCtx.CurrentMode() == types.Text})
 	}
 	CloseBrowserHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -268,7 +268,7 @@ var (
 			}
 			return mcp.NewToolResultText("Close browser successfully"), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: false})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
 	EvaluateHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -288,7 +288,7 @@ var (
 			}
 			return mcp.NewToolResultText(fmt.Sprintf("Evaluate code successfully with result: %s", r.Result.Value.String())), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: false})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
 	ScreenshotHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -309,7 +309,7 @@ var (
 			encoded := base64.StdEncoding.EncodeToString(bin)
 			return mcp.NewToolResultImage(fmt.Sprintf("Screenshot captured: %s", fileName), encoded, "image/png"), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: false})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
 	SetHeadersHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -334,7 +334,7 @@ var (
 			}
 			return mcp.NewToolResultText(fmt.Sprintf("Set %d headers successfully", len(headersMap))), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: false})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
 )
 

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -52,13 +52,13 @@ var (
 		handler := func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			snapshot, err := rodCtx.BuildSnapshot()
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to capture snapshoot")
+				return nil, errors.Wrapf(err, "Failed to capture snapshot")
 			}
 
 			return mcp.NewToolResultText(snapshot), nil
 
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: false})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
 
 	ClickHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
@@ -91,7 +91,7 @@ var (
 			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
 			return mcp.NewToolResultText(fmt.Sprintf("Click element %s successfully", ele)), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: true})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
 	}
 
 	FillHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
@@ -141,7 +141,7 @@ var (
 			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
 			return mcp.NewToolResultText(fmt.Sprintf("Fill out element %s successfully", ele)), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: true})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
 	}
 
 	SelectorHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
@@ -178,7 +178,7 @@ var (
 			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
 			return mcp.NewToolResultText(fmt.Sprintf("Select option(s) in element %s successfully", ele)), nil
 		}
-		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WitSnapshot: true})
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
 	}
 )
 

--- a/types/context.go
+++ b/types/context.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	"github.com/go-rod/rod"
 	"github.com/aliwatters/rod-mcp/types/js"
@@ -100,10 +99,9 @@ type Context struct {
 	stdContext context.Context
 	config     Config
 	browser    *rod.Browser
-	page       *rod.Page
-	stateLock  sync.Mutex
-	isInitial  atomic.Bool
-	snapshot   *Snapshot
+	page      *rod.Page
+	stateLock sync.Mutex
+	snapshot  *Snapshot
 	mode       Mode
 }
 
@@ -174,7 +172,7 @@ func (ctx *Context) Execute(handlerFunc server.ToolHandlerFunc, handlerCallOpts 
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		if handlerCallOpts.WitSnapshot {
+		if handlerCallOpts.WithSnapshot {
 			snapshot, _ := ctx.BuildSnapshot()
 			result.Content = append(result.Content, mcp.TextContent{
 				Type: "text",
@@ -256,11 +254,7 @@ func (ctx *Context) createPage(urls ...string) (*rod.Page, error) {
 	// Apply HTTP headers from config (global + domain-specific)
 	allHeaders := ctx.config.GetHeadersForURL(targetURL)
 	if len(allHeaders) > 0 {
-		headers := make([]string, 0, len(allHeaders)*2)
-		for k, v := range allHeaders {
-			headers = append(headers, k, v)
-		}
-		if _, err := page.SetExtraHeaders(headers); err != nil {
+		if _, err := page.SetExtraHeaders(utils.HeaderMapToSlice(allHeaders)); err != nil {
 			return nil, errors.Wrap(err, "set extra HTTP headers failed")
 		}
 	}
@@ -277,11 +271,7 @@ func (ctx *Context) UpdateHeadersForURL(url string) error {
 
 	allHeaders := ctx.config.GetHeadersForURL(url)
 	if len(allHeaders) > 0 {
-		headers := make([]string, 0, len(allHeaders)*2)
-		for k, v := range allHeaders {
-			headers = append(headers, k, v)
-		}
-		if _, err := ctx.page.SetExtraHeaders(headers); err != nil {
+		if _, err := ctx.page.SetExtraHeaders(utils.HeaderMapToSlice(allHeaders)); err != nil {
 			return errors.Wrap(err, "set extra HTTP headers failed")
 		}
 	}

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -39,7 +39,7 @@ func BuildSnapshot(p *rod.Page, compact bool) (*Snapshot, error) {
 
 	yamlBytes, err := yaml.Marshal(yamlDoc)
 	if err != nil {
-		return nil, errors.Wrapf(err, "capture snapshot with frames failed,because of yaml marsha")
+		return nil, errors.Wrapf(err, "capture snapshot with frames failed,because of yaml marshal")
 	}
 
 	pageInfo, err := p.Info()
@@ -53,9 +53,9 @@ func BuildSnapshot(p *rod.Page, compact bool) (*Snapshot, error) {
 		"Snapshot": strings.TrimSpace(string(yamlBytes)),
 		"Frames":   len(snapshot.frames),
 	}
-	res, err := utils.ExecuteTemple(snapshotTpl, tplInfo)
+	res, err := utils.ExecuteTemplate(snapshotTpl, tplInfo)
 	if err != nil {
-		return nil, errors.Wrapf(err, "capture snapshot with frames failed, because of tple exec failed")
+		return nil, errors.Wrapf(err, "capture snapshot with frames failed, because of template exec failed")
 	}
 	snapshot.textSnapshot = res
 	return snapshot, nil

--- a/types/tool.go
+++ b/types/tool.go
@@ -1,5 +1,5 @@
 package types
 
 type ToolHandlerCallOpts struct {
-	WitSnapshot bool
+	WithSnapshot bool
 }

--- a/utils/net.go
+++ b/utils/net.go
@@ -5,3 +5,13 @@ import "strings"
 func IsHttp(raw string) bool {
 	return strings.HasPrefix(strings.TrimSpace(raw), "http://") || strings.HasPrefix(strings.TrimSpace(raw), "https://")
 }
+
+// HeaderMapToSlice converts a map of HTTP headers to a flat key-value slice
+// suitable for Rod's SetExtraHeaders.
+func HeaderMapToSlice(m map[string]string) []string {
+	headers := make([]string, 0, len(m)*2)
+	for k, v := range m {
+		headers = append(headers, k, v)
+	}
+	return headers
+}

--- a/utils/str.go
+++ b/utils/str.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"math/rand"
 	"text/template"
-	"time"
 )
 
 func RandomString(length int) string {
-	rand.Seed(time.Now().UnixNano())
 	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	result := make([]rune, length)
 	for i := range result {
@@ -17,9 +15,9 @@ func RandomString(length int) string {
 	return string(result)
 }
 
-func ExecuteTemple(temple string, res any) (string, error) {
+func ExecuteTemplate(tmplStr string, res any) (string, error) {
 	var out bytes.Buffer
-	tmpl, err := template.New("tpl").Parse(temple)
+	tmpl, err := template.New("tpl").Parse(tmplStr)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

- Remove unused `isInitial` field from `Context` struct (#21)
- Remove unused `resources/` package — `console.go` and `network.go` were never registered (#22)
- Extract `HeaderMapToSlice` helper to deduplicate header conversion in `context.go` (#25)
- Fix typos: `WitSnapshot`→`WithSnapshot`, `ExecuteTemple`→`ExecuteTemplate`, `snapshoot`→`snapshot`, `marsha`→`marshal`, `tple`→`template` (#26)
- Remove deprecated `rand.Seed` call in `utils/str.go` (#29)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go mod tidy` produces no changes
- [x] Net -20 lines (36 added, 56 removed)

Closes #21, closes #22, closes #25, closes #26, closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)