### PR TITLE
feat: implement PDF generation tool

### DIFF
--- a/tools/common.go
+++ b/tools/common.go
@@ -5,14 +5,17 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/charmbracelet/log"
-	"github.com/aliwatters/rod-mcp/types"
-	"github.com/aliwatters/rod-mcp/utils"
 	"github.com/go-rod/rod/lib/input"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	"time"
+
+	"github.com/aliwatters/rod-mcp/types"
+	"github.com/aliwatters/rod-mcp/utils"
 )
 
 const (
@@ -127,9 +130,8 @@ var (
 		mcp.WithString("key", mcp.Description("Name of the key to press or a character to generate, such as `ArrowLeft` or `a`"), mcp.Required()),
 	)
 	Pdf = mcp.NewTool(PdfToolKey,
-		mcp.WithDescription("Generate a PDF from the current page"),
-		mcp.WithString("file_path", mcp.Description("Path to save the PDF file"), mcp.Required()),
-		mcp.WithString("file_name", mcp.Description("Name of the PDF file"), mcp.Required()),
+		mcp.WithDescription("Generate a PDF of the current page and return as base64 data"),
+		mcp.WithString("name", mcp.Description("Name or description of the PDF"), mcp.Required()),
 	)
 	CloseBrowser = mcp.NewTool(CloseBrowserToolKey,
 		mcp.WithDescription("Close the browser"),
@@ -311,6 +313,36 @@ var (
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
+	PdfHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				log.Errorf("Failed to generate PDF: %s", err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to generate PDF: %s", err.Error()))
+			}
+			reader, err := page.PDF(&proto.PagePrintToPDF{})
+			if err != nil {
+				log.Errorf("Failed to generate PDF: %s", err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to generate PDF: %s", err.Error()))
+			}
+			bin, err := io.ReadAll(reader)
+			if err != nil {
+				log.Errorf("Failed to read PDF data: %s", err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to read PDF data: %s", err.Error()))
+			}
+			name := request.Params.Arguments["name"].(string)
+			encoded := base64.StdEncoding.EncodeToString(bin)
+			return mcp.NewToolResultResource(
+				fmt.Sprintf("PDF generated: %s", name),
+				mcp.BlobResourceContents{
+					URI:      fmt.Sprintf("pdf://%s", name),
+					MIMEType: "application/pdf",
+					Blob:     encoded,
+				},
+			), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
 	SetHeadersHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			page, err := rodCtx.EnsurePage()
@@ -346,6 +378,7 @@ var (
 		ReLoad,
 		PressKey,
 		Screenshot,
+		Pdf,
 		Evaluate,
 		CloseBrowser,
 		SetHeaders,
@@ -357,6 +390,7 @@ var (
 		ReloadToolKey:       ReLoadHandler,
 		PressKeyToolKey:     PressKeyHandler,
 		ScreenshotToolKey:   ScreenshotHandler,
+		PdfToolKey:          PdfHandler,
 		EvaluateToolKey:     EvaluateHandler,
 		CloseBrowserToolKey: CloseBrowserHandler,
 		SetHeadersToolKey:   SetHeadersHandler,

--- a/tools/common_test.go
+++ b/tools/common_test.go
@@ -6,6 +6,98 @@ import (
 	"github.com/go-rod/rod/lib/input"
 )
 
+func TestPdfToolDefinition(t *testing.T) {
+	if Pdf.Name != PdfToolKey {
+		t.Errorf("Pdf tool name = %q, want %q", Pdf.Name, PdfToolKey)
+	}
+
+	// Verify "name" parameter exists and is required
+	props := Pdf.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Pdf tool has no properties")
+	}
+	if _, ok := props["name"]; !ok {
+		t.Error("Pdf tool missing 'name' property")
+	}
+
+	// Verify old file_path/file_name params are removed
+	if _, ok := props["file_path"]; ok {
+		t.Error("Pdf tool should not have 'file_path' property")
+	}
+	if _, ok := props["file_name"]; ok {
+		t.Error("Pdf tool should not have 'file_name' property")
+	}
+
+	// Verify "name" is required
+	required := Pdf.InputSchema.Required
+	found := false
+	for _, r := range required {
+		if r == "name" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Pdf tool 'name' parameter should be required")
+	}
+}
+
+func TestPdfToolRegistered(t *testing.T) {
+	// Verify Pdf is in CommonTools
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == PdfToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Pdf tool not found in CommonTools")
+	}
+
+	// Verify PdfHandler is in CommonToolHandlers
+	if _, ok := CommonToolHandlers[PdfToolKey]; !ok {
+		t.Error("PdfHandler not found in CommonToolHandlers")
+	}
+}
+
+func TestAllCommonToolsHaveHandlers(t *testing.T) {
+	for _, tool := range CommonTools {
+		if _, ok := CommonToolHandlers[tool.Name]; !ok {
+			t.Errorf("Tool %q registered in CommonTools but missing from CommonToolHandlers", tool.Name)
+		}
+	}
+}
+
+func TestAllCommonHandlersHaveTools(t *testing.T) {
+	toolNames := make(map[string]bool)
+	for _, tool := range CommonTools {
+		toolNames[tool.Name] = true
+	}
+	for name := range CommonToolHandlers {
+		if !toolNames[name] {
+			t.Errorf("Handler %q registered in CommonToolHandlers but missing from CommonTools", name)
+		}
+	}
+}
+
+func TestTextToolsIncludesPdf(t *testing.T) {
+	found := false
+	for _, tool := range TextTools {
+		if tool.Name == PdfToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Pdf tool not found in TextTools (should be included via CommonTools)")
+	}
+
+	if _, ok := TextToolHandlers[PdfToolKey]; !ok {
+		t.Error("PdfHandler not found in TextToolHandlers (should be included via CommonToolHandlers)")
+	}
+}
+
 func TestParseKey(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- Implement `rod_pdf` tool handler using `page.PDF()` with `proto.PagePrintToPDF`
- Return PDF as base64-encoded `BlobResourceContents` via MCP (no filesystem writes)
- Update tool definition: remove `file_path`/`file_name` params, add `name` param
- Register tool and handler in `CommonTools`/`CommonToolHandlers`
- Add tests for tool definition, registration, and tool/handler consistency

## Changes
- `tools/common.go` — Add `PdfHandler`, update `Pdf` tool definition, register in common sets
- `tools/common_test.go` — Add PDF tool tests + consistency tests for all common tools/handlers

## Testing
- `go test ./...` — All passing
- `go vet ./...` — Clean
- `go build ./...` — Clean

Fixes #20