### PR TITLE
feat: save screenshots/PDFs to files, make inline base64 configurable

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -15,6 +15,8 @@ type SubCfg struct {
 	Mode            types.Mode
 	CDPEndpoint     string
 	CompactSnapshot bool
+	OutputDir       string
+	OmitImages      bool
 }
 
 func RunCmd() (*SubCfg, error) {
@@ -58,6 +60,15 @@ func RunCmd() (*SubCfg, error) {
 				Aliases: []string{"cs"},
 				Usage:   "enable compact snapshot mode to reduce token usage by filtering non-interactive elements",
 			},
+			&cli.StringFlag{
+				Name:        "output-dir",
+				Usage:       "directory for saving screenshots and PDFs (default: OS temp dir)",
+				Destination: &subConfig.OutputDir,
+			},
+			&cli.BoolFlag{
+				Name:    "omit-images",
+				Usage:   "omit inline base64 image data from screenshot results (saves tokens)",
+			},
 		},
 		Before: func(c *cli.Context) error {
 			if !c.Bool("no-banner") {
@@ -76,6 +87,9 @@ func RunCmd() (*SubCfg, error) {
 			}
 			if c.Bool("compact-snapshot") {
 				subConfig.CompactSnapshot = true
+			}
+			if c.Bool("omit-images") {
+				subConfig.OmitImages = true
 			}
 			return nil
 		},

--- a/main.go
+++ b/main.go
@@ -42,6 +42,14 @@ func main() {
 		cfg.CompactSnapshot = true
 	}
 
+	if subCfg.OutputDir != "" {
+		cfg.OutputDir = subCfg.OutputDir
+	}
+
+	if subCfg.OmitImages {
+		cfg.ImageResponses = types.ImageResponsesOmit
+	}
+
 	runner := NewRunner(ctx, *cfg)
 	go func() {
 		c := make(chan os.Signal, 1)

--- a/tools/common.go
+++ b/tools/common.go
@@ -130,7 +130,7 @@ var (
 		mcp.WithString("key", mcp.Description("Name of the key to press or a character to generate, such as `ArrowLeft` or `a`"), mcp.Required()),
 	)
 	Pdf = mcp.NewTool(PdfToolKey,
-		mcp.WithDescription("Generate a PDF of the current page and return as base64 data"),
+		mcp.WithDescription("Generate a PDF of the current page and save to the output directory"),
 		mcp.WithString("name", mcp.Description("Name or description of the PDF"), mcp.Required()),
 	)
 	CloseBrowser = mcp.NewTool(CloseBrowserToolKey,
@@ -307,9 +307,25 @@ var (
 				log.Errorf("Failed to screenshot: %s", err.Error())
 				return nil, errors.New(fmt.Sprintf("Failed to capture screenshot: %s", err.Error()))
 			}
-			fileName := request.Params.Arguments["name"].(string)
-			encoded := base64.StdEncoding.EncodeToString(bin)
-			return mcp.NewToolResultImage(fmt.Sprintf("Screenshot captured: %s", fileName), encoded, "image/png"), nil
+			name := request.Params.Arguments["name"].(string)
+
+			// Always save to file
+			cfg := rodCtx.Config()
+			path, err := types.SaveOutput(cfg, bin, "screenshot", "png")
+			if err != nil {
+				log.Errorf("Failed to save screenshot: %s", err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to save screenshot: %s", err.Error()))
+			}
+
+			// Return file path + optional inline image
+			if cfg.ImageResponses != types.ImageResponsesOmit {
+				encoded := base64.StdEncoding.EncodeToString(bin)
+				return mcp.NewToolResultImage(
+					fmt.Sprintf("Screenshot saved: %s (%s)", name, path),
+					encoded, "image/png",
+				), nil
+			}
+			return mcp.NewToolResultText(fmt.Sprintf("Screenshot saved: %s (%s)", name, path)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
@@ -331,15 +347,15 @@ var (
 				return nil, errors.New(fmt.Sprintf("Failed to read PDF data: %s", err.Error()))
 			}
 			name := request.Params.Arguments["name"].(string)
-			encoded := base64.StdEncoding.EncodeToString(bin)
-			return mcp.NewToolResultResource(
-				fmt.Sprintf("PDF generated: %s", name),
-				mcp.BlobResourceContents{
-					URI:      fmt.Sprintf("pdf://%s", name),
-					MIMEType: "application/pdf",
-					Blob:     encoded,
-				},
-			), nil
+
+			// Always save to file, never return inline (PDFs can't be rendered inline by MCP clients)
+			cfg := rodCtx.Config()
+			path, err := types.SaveOutput(cfg, bin, "page", "pdf")
+			if err != nil {
+				log.Errorf("Failed to save PDF: %s", err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to save PDF: %s", err.Error()))
+			}
+			return mcp.NewToolResultText(fmt.Sprintf("PDF saved: %s (%s)", name, path)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}

--- a/tools/common_test.go
+++ b/tools/common_test.go
@@ -11,6 +11,11 @@ func TestPdfToolDefinition(t *testing.T) {
 		t.Errorf("Pdf tool name = %q, want %q", Pdf.Name, PdfToolKey)
 	}
 
+	// Verify description mentions saving to output directory
+	if Pdf.Description != "Generate a PDF of the current page and save to the output directory" {
+		t.Errorf("Pdf tool description = %q, want file-based description", Pdf.Description)
+	}
+
 	// Verify "name" parameter exists and is required
 	props := Pdf.InputSchema.Properties
 	if props == nil {

--- a/types/config.go
+++ b/types/config.go
@@ -11,6 +11,16 @@ import (
 
 const ConfigName = "rod-mcp.yaml"
 
+// ImageResponsesMode controls whether inline base64 image data is included in tool results.
+type ImageResponsesMode string
+
+const (
+	// ImageResponsesAllow includes inline base64 image data alongside the saved file path.
+	ImageResponsesAllow ImageResponsesMode = "allow"
+	// ImageResponsesOmit returns only the file path, omitting inline base64 data to save tokens.
+	ImageResponsesOmit ImageResponsesMode = "omit"
+)
+
 type Config struct {
 	Mode             Mode              `yaml:"mode" json:"mode"`
 	CDPEndpoint      string            `yaml:"cdpEndpoint" json:"cdpEndpoint"`
@@ -28,6 +38,13 @@ type Config struct {
 	// Patterns support wildcards: "*.example.com" matches "www.example.com", "api.example.com", etc.
 	// Headers from matching patterns are merged with ExtraHTTPHeaders.
 	DomainHeaders map[string]map[string]string `yaml:"domainHeaders" json:"domainHeaders"`
+	// OutputDir is the directory where screenshots and PDFs are saved.
+	// Defaults to a "rod-mcp" subdirectory in the OS temp directory.
+	OutputDir string `yaml:"outputDir" json:"outputDir"`
+	// ImageResponses controls whether inline base64 image data is included in screenshot results.
+	// "allow" (default): saves file and includes inline base64 ImageContent.
+	// "omit": saves file only, returns just the file path (saves tokens).
+	ImageResponses ImageResponsesMode `yaml:"imageResponses" json:"imageResponses"`
 }
 
 var (
@@ -43,6 +60,7 @@ var (
 		ServerName:     DefaultServerName,
 		LoggerConfig:   DefaultLoggerConfig,
 		Mode:           Text,
+		ImageResponses: ImageResponsesAllow,
 	}
 )
 

--- a/types/context.go
+++ b/types/context.go
@@ -161,6 +161,10 @@ func (ctx *Context) CurrentMode() Mode {
 	return ctx.mode
 }
 
+func (ctx *Context) Config() Config {
+	return ctx.config
+}
+
 func (ctx *Context) ClosePage() error {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()

--- a/types/output.go
+++ b/types/output.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const defaultOutputSubdir = "rod-mcp"
+
+// ResolveOutputDir returns the output directory, creating it if necessary.
+// If cfg.OutputDir is set, uses that. Otherwise uses os.TempDir()/rod-mcp.
+func ResolveOutputDir(cfg Config) (string, error) {
+	dir := cfg.OutputDir
+	if dir == "" {
+		dir = filepath.Join(os.TempDir(), defaultOutputSubdir)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create output directory %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// SaveOutput writes data to a timestamped file in the output directory.
+// Returns the absolute path to the saved file.
+func SaveOutput(cfg Config, data []byte, prefix, ext string) (string, error) {
+	dir, err := ResolveOutputDir(cfg)
+	if err != nil {
+		return "", err
+	}
+	filename := fmt.Sprintf("%s-%s.%s", prefix, time.Now().Format("20060102-150405"), ext)
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	return path, nil
+}

--- a/types/output_test.go
+++ b/types/output_test.go
@@ -1,0 +1,111 @@
+package types
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveOutputDir_Default(t *testing.T) {
+	cfg := Config{}
+	dir, err := ResolveOutputDir(cfg)
+	if err != nil {
+		t.Fatalf("ResolveOutputDir() error = %v", err)
+	}
+	expected := filepath.Join(os.TempDir(), defaultOutputSubdir)
+	if dir != expected {
+		t.Errorf("ResolveOutputDir() = %q, want %q", dir, expected)
+	}
+	// Verify directory was created
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("output dir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("output dir is not a directory")
+	}
+}
+
+func TestResolveOutputDir_Custom(t *testing.T) {
+	dir := t.TempDir()
+	custom := filepath.Join(dir, "my-output")
+	cfg := Config{OutputDir: custom}
+
+	got, err := ResolveOutputDir(cfg)
+	if err != nil {
+		t.Fatalf("ResolveOutputDir() error = %v", err)
+	}
+	if got != custom {
+		t.Errorf("ResolveOutputDir() = %q, want %q", got, custom)
+	}
+	info, err := os.Stat(custom)
+	if err != nil {
+		t.Fatalf("custom output dir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("custom output dir is not a directory")
+	}
+}
+
+func TestSaveOutput(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{OutputDir: dir}
+	data := []byte("test content")
+
+	path, err := SaveOutput(cfg, data, "screenshot", "png")
+	if err != nil {
+		t.Fatalf("SaveOutput() error = %v", err)
+	}
+
+	// Verify file path structure
+	if !strings.HasPrefix(path, dir) {
+		t.Errorf("path %q does not start with %q", path, dir)
+	}
+	if !strings.HasPrefix(filepath.Base(path), "screenshot-") {
+		t.Errorf("filename %q does not start with 'screenshot-'", filepath.Base(path))
+	}
+	if !strings.HasSuffix(path, ".png") {
+		t.Errorf("path %q does not end with '.png'", path)
+	}
+
+	// Verify file contents
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read saved file: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("file content = %q, want %q", got, data)
+	}
+}
+
+func TestSaveOutput_PDF(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{OutputDir: dir}
+	data := []byte("%PDF-1.4 fake pdf content")
+
+	path, err := SaveOutput(cfg, data, "page", "pdf")
+	if err != nil {
+		t.Fatalf("SaveOutput() error = %v", err)
+	}
+
+	if !strings.HasPrefix(filepath.Base(path), "page-") {
+		t.Errorf("filename %q does not start with 'page-'", filepath.Base(path))
+	}
+	if !strings.HasSuffix(path, ".pdf") {
+		t.Errorf("path %q does not end with '.pdf'", path)
+	}
+}
+
+func TestImageResponsesMode_Defaults(t *testing.T) {
+	// Default config should have ImageResponses = "allow"
+	if DefaultConfig.ImageResponses != ImageResponsesAllow {
+		t.Errorf("DefaultConfig.ImageResponses = %q, want %q", DefaultConfig.ImageResponses, ImageResponsesAllow)
+	}
+
+	// Zero-value Config should have empty ImageResponses (treated as allow by handlers)
+	cfg := Config{}
+	if cfg.ImageResponses == ImageResponsesOmit {
+		t.Error("zero-value Config.ImageResponses should not be 'omit'")
+	}
+}


### PR DESCRIPTION
## Summary

- Screenshots and PDFs now save to files in the output directory (default: `$TMPDIR/rod-mcp`)
- Screenshots optionally include inline base64 `ImageContent`, controlled by `imageResponses` config
- PDFs never include inline data (MCP clients can't render them anyway)
- New config options: `outputDir`, `imageResponses` ("allow" | "omit")
- New CLI flags: `--output-dir`, `--omit-images`

## Why

Base64 data returned from MCP tools burns excessive tokens in Claude Code:
- A screenshot as base64 text: ~100,000-140,000 tokens
- Same image via vision API: ~1,600 tokens (50-120x cheaper)
- Claude Code [bug #9152](https://github.com/anthropics/claude-code/issues/9152): `ImageContent` tokenized as text, not vision tokens

This follows Playwright MCP's approach: file-first, inline optional.

## Changes

| File | Change |
|---|---|
| `types/config.go` | Add `OutputDir`, `ImageResponses` config fields with `ImageResponsesMode` type |
| `types/output.go` | New: `ResolveOutputDir()` and `SaveOutput()` utilities |
| `types/output_test.go` | New: Tests for output dir resolution, file saving, config defaults |
| `types/context.go` | Add `Config()` accessor for handlers |
| `tools/common.go` | Update `ScreenshotHandler` (file + optional inline) and `PdfHandler` (file only) |
| `tools/common_test.go` | Update PDF tool description test |
| `cmd.go` | Add `--output-dir` and `--omit-images` CLI flags |
| `main.go` | Wire new CLI flags to config |

## Testing

- `go test ./...` — All passing
- `go vet ./...` — Clean
- `go build ./...` — Clean

Fixes #34