### PR TITLE
feat: add tab management tools

### DIFF
--- a/tools/common.go
+++ b/tools/common.go
@@ -111,6 +111,10 @@ const (
 	SetHeadersToolKey    = "rod_set_headers"
 	ResizeToolKey        = "rod_resize"
 	HandleDialogToolKey  = "rod_handle_dialog"
+	TabNewToolKey        = "rod_tab_new"
+	TabListToolKey       = "rod_tab_list"
+	TabSelectToolKey     = "rod_tab_select"
+	TabCloseToolKey      = "rod_tab_close"
 )
 
 var (
@@ -164,6 +168,21 @@ var (
 		mcp.WithDescription("Handle a JavaScript dialog (alert, confirm, prompt). Use this when a dialog is blocking page interaction."),
 		mcp.WithString("action", mcp.Description("accept or dismiss"), mcp.Required()),
 		mcp.WithString("text", mcp.Description("Text to enter for prompt() dialogs before accepting")),
+	)
+	TabNew = mcp.NewTool(TabNewToolKey,
+		mcp.WithDescription("Open a new browser tab, optionally navigating to a URL"),
+		mcp.WithString("url", mcp.Description("URL to navigate to in the new tab")),
+	)
+	TabList = mcp.NewTool(TabListToolKey,
+		mcp.WithDescription("List all open browser tabs with their titles, URLs, and which is active"),
+	)
+	TabSelect = mcp.NewTool(TabSelectToolKey,
+		mcp.WithDescription("Switch to a specific browser tab by index"),
+		mcp.WithNumber("index", mcp.Description("Tab index (from rod_tab_list)"), mcp.Required()),
+	)
+	TabClose = mcp.NewTool(TabCloseToolKey,
+		mcp.WithDescription("Close a browser tab by index"),
+		mcp.WithNumber("index", mcp.Description("Tab index to close (from rod_tab_list)"), mcp.Required()),
 	)
 )
 
@@ -463,6 +482,74 @@ var (
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
+	TabNewHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			url := ""
+			if u, ok := request.Params.Arguments["url"].(string); ok {
+				url = u
+			}
+			if url != "" && !utils.IsHttp(url) {
+				return nil, errors.New("invalid URL")
+			}
+			_, err := rodCtx.NewTab(url)
+			if err != nil {
+				log.Errorf("Failed to create new tab: %s", err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to create new tab: %s", err.Error()))
+			}
+			if url != "" {
+				return mcp.NewToolResultText(fmt.Sprintf("New tab opened and navigated to %s", url)), nil
+			}
+			return mcp.NewToolResultText("New tab opened"), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+	TabListHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			tabs, err := rodCtx.ListTabs()
+			if err != nil {
+				log.Errorf("Failed to list tabs: %s", err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to list tabs: %s", err.Error()))
+			}
+			var result string
+			for _, tab := range tabs {
+				active := ""
+				if tab.IsActive {
+					active = " (active)"
+				}
+				result += fmt.Sprintf("[%d] %s - %s%s\n", tab.Index, tab.Title, tab.URL, active)
+			}
+			return mcp.NewToolResultText(result), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+	TabSelectHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			index := int(request.Params.Arguments["index"].(float64))
+			page, err := rodCtx.SelectTab(index)
+			if err != nil {
+				log.Errorf("Failed to select tab: %s", err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to select tab: %s", err.Error()))
+			}
+			info, err := page.Info()
+			if err != nil {
+				return mcp.NewToolResultText(fmt.Sprintf("Switched to tab %d", index)), nil
+			}
+			return mcp.NewToolResultText(fmt.Sprintf("Switched to tab %d: %s - %s", index, info.Title, info.URL)), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: rodCtx.CurrentMode() == types.Text})
+	}
+	TabCloseHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			index := int(request.Params.Arguments["index"].(float64))
+			err := rodCtx.CloseTab(index)
+			if err != nil {
+				log.Errorf("Failed to close tab: %s", err.Error())
+				return nil, errors.New(fmt.Sprintf("Failed to close tab: %s", err.Error()))
+			}
+			return mcp.NewToolResultText(fmt.Sprintf("Tab %d closed", index)), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
 )
 
 var (
@@ -479,6 +566,10 @@ var (
 		SetHeaders,
 		Resize,
 		HandleDialog,
+		TabNew,
+		TabList,
+		TabSelect,
+		TabClose,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		NavigationToolKey:   NavigationHandler,
@@ -493,5 +584,9 @@ var (
 		SetHeadersToolKey:   SetHeadersHandler,
 		ResizeToolKey:        ResizeHandler,
 		HandleDialogToolKey: HandleDialogHandler,
+		TabNewToolKey:       TabNewHandler,
+		TabListToolKey:      TabListHandler,
+		TabSelectToolKey:    TabSelectHandler,
+		TabCloseToolKey:     TabCloseHandler,
 	}
 )

--- a/types/context.go
+++ b/types/context.go
@@ -273,6 +273,131 @@ func (ctx *Context) createPage(urls ...string) (*rod.Page, error) {
 	return page, nil
 }
 
+// TabInfo represents a tab's metadata for listing.
+type TabInfo struct {
+	Index    int    `json:"index"`
+	Title    string `json:"title"`
+	URL      string `json:"url"`
+	IsActive bool   `json:"is_active"`
+}
+
+// NewTab creates a new tab, optionally navigating to a URL, and makes it the active page.
+func (ctx *Context) NewTab(url string) (*rod.Page, error) {
+	if err := ctx.initial(); err != nil {
+		return nil, err
+	}
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	var page *rod.Page
+	var err error
+	if url != "" {
+		page, err = ctx.createPage(url)
+	} else {
+		page, err = ctx.createPage()
+	}
+	if err != nil {
+		return nil, err
+	}
+	ctx.page = page
+	return page, nil
+}
+
+// ListTabs returns info about all open tabs, marking which is active.
+func (ctx *Context) ListTabs() ([]TabInfo, error) {
+	if err := ctx.initial(); err != nil {
+		return nil, err
+	}
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	pages, err := ctx.browser.Pages()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list tabs")
+	}
+
+	tabs := make([]TabInfo, 0, len(pages))
+	for i, p := range pages {
+		info, err := p.Info()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get tab info")
+		}
+		tabs = append(tabs, TabInfo{
+			Index:    i,
+			Title:    info.Title,
+			URL:      info.URL,
+			IsActive: ctx.page != nil && p.TargetID == ctx.page.TargetID,
+		})
+	}
+	return tabs, nil
+}
+
+// SelectTab switches the active page to the tab at the given index.
+func (ctx *Context) SelectTab(index int) (*rod.Page, error) {
+	if err := ctx.initial(); err != nil {
+		return nil, err
+	}
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	pages, err := ctx.browser.Pages()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list tabs")
+	}
+	if index < 0 || index >= len(pages) {
+		return nil, fmt.Errorf("tab index %d out of range (0-%d)", index, len(pages)-1)
+	}
+	ctx.page = pages[index]
+	return ctx.page, nil
+}
+
+// CloseTab closes the tab at the given index. If it's the active tab,
+// switches to the nearest remaining tab.
+func (ctx *Context) CloseTab(index int) error {
+	if err := ctx.initial(); err != nil {
+		return err
+	}
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	pages, err := ctx.browser.Pages()
+	if err != nil {
+		return errors.Wrap(err, "failed to list tabs")
+	}
+	if index < 0 || index >= len(pages) {
+		return fmt.Errorf("tab index %d out of range (0-%d)", index, len(pages)-1)
+	}
+	if len(pages) == 1 {
+		return errors.New("cannot close the last tab")
+	}
+
+	target := pages[index]
+	isActive := ctx.page != nil && target.TargetID == ctx.page.TargetID
+
+	if err := target.Close(); err != nil {
+		return errors.Wrap(err, "failed to close tab")
+	}
+
+	if isActive {
+		// Switch to nearest tab
+		remaining, err := ctx.browser.Pages()
+		if err != nil {
+			return errors.Wrap(err, "failed to list tabs after close")
+		}
+		if len(remaining) > 0 {
+			newIndex := index
+			if newIndex >= len(remaining) {
+				newIndex = len(remaining) - 1
+			}
+			ctx.page = remaining[newIndex]
+		} else {
+			ctx.page = nil
+		}
+	}
+
+	return nil
+}
+
 // UpdateHeadersForURL updates the extra HTTP headers on the current page based on the target URL.
 // This should be called before navigating to a new domain to ensure domain-specific headers are applied.
 func (ctx *Context) UpdateHeadersForURL(url string) error {


### PR DESCRIPTION
## Summary
- Add `rod_tab_new` tool to open new tabs with optional URL navigation
- Add `rod_tab_list` tool to list all open tabs with title, URL, and active status
- Add `rod_tab_select` tool to switch active tab by index
- Add `rod_tab_close` tool to close a tab by index (auto-switches active tab)
- Add `NewTab`, `ListTabs`, `SelectTab`, `CloseTab` methods to `types.Context`

Closes #9