### PR TITLE
feat: add rod_console_messages tool

### DIFF
--- a/tools/common.go
+++ b/tools/common.go
@@ -120,7 +120,8 @@ const (
 	TabListToolKey       = "rod_tab_list"
 	TabSelectToolKey     = "rod_tab_select"
 	TabCloseToolKey      = "rod_tab_close"
-	WaitForToolKey       = "rod_wait_for"
+	WaitForToolKey          = "rod_wait_for"
+	ConsoleMessagesToolKey  = "rod_console_messages"
 )
 
 var (
@@ -196,6 +197,11 @@ var (
 		mcp.WithString("text", mcp.Description("Text content to wait for on the page")),
 		mcp.WithString("state", mcp.Description("Element state to wait for: visible (default), hidden, attached, detached")),
 		mcp.WithNumber("timeout", mcp.Description("Max wait time in milliseconds (default: 30000)")),
+	)
+	ConsoleMessages = mcp.NewTool(ConsoleMessagesToolKey,
+		mcp.WithDescription("Return captured browser console messages (log, warn, error, info)"),
+		mcp.WithString("level", mcp.Description("Filter by level: log, warn, error, info (returns all if not specified)")),
+		mcp.WithBoolean("clear", mcp.Description("Clear captured messages after returning (default: false)")),
 	)
 )
 
@@ -605,6 +611,25 @@ var (
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
+	ConsoleMessagesHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			filterLevel, _ := request.Params.Arguments["level"].(string)
+			clear, _ := request.Params.Arguments["clear"].(bool)
+
+			messages := rodCtx.ConsoleMessages(filterLevel, clear)
+			if len(messages) == 0 {
+				return mcp.NewToolResultText("No console messages captured"), nil
+			}
+
+			var result string
+			for _, msg := range messages {
+				result += fmt.Sprintf("[%s] %s\n", msg.Level, msg.Text)
+			}
+			result += fmt.Sprintf("\nTotal: %d messages", len(messages))
+			return mcp.NewToolResultText(result), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
 )
 
 var (
@@ -626,6 +651,7 @@ var (
 		TabSelect,
 		TabClose,
 		WaitFor,
+		ConsoleMessages,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		NavigationToolKey:   NavigationHandler,
@@ -644,6 +670,7 @@ var (
 		TabListToolKey:      TabListHandler,
 		TabSelectToolKey:    TabSelectHandler,
 		TabCloseToolKey:     TabCloseHandler,
-		WaitForToolKey:      WaitForHandler,
+		WaitForToolKey:         WaitForHandler,
+		ConsoleMessagesToolKey: ConsoleMessagesHandler,
 	}
 )

--- a/types/context.go
+++ b/types/context.go
@@ -96,14 +96,21 @@ const (
 	Text Mode = "text"
 )
 
+// ConsoleMessage represents a captured browser console message.
+type ConsoleMessage struct {
+	Level string `json:"level"`
+	Text  string `json:"text"`
+}
+
 type Context struct {
-	stdContext context.Context
-	config     Config
-	browser    *rod.Browser
-	page      *rod.Page
-	stateLock sync.Mutex
-	snapshot  *Snapshot
-	mode       Mode
+	stdContext       context.Context
+	config          Config
+	browser         *rod.Browser
+	page            *rod.Page
+	stateLock       sync.Mutex
+	snapshot        *Snapshot
+	mode            Mode
+	consoleMessages []ConsoleMessage
 }
 
 func NewContext(ctx context.Context, cfg Config) *Context {
@@ -270,7 +277,53 @@ func (ctx *Context) createPage(urls ...string) (*rod.Page, error) {
 		}
 	}
 
+	// Listen for console messages
+	go page.EachEvent(func(e *proto.RuntimeConsoleAPICalled) {
+		var parts []string
+		for _, arg := range e.Args {
+			parts = append(parts, arg.Value.String())
+		}
+		text := strings.Join(parts, " ")
+		ctx.stateLock.Lock()
+		ctx.consoleMessages = append(ctx.consoleMessages, ConsoleMessage{
+			Level: string(e.Type),
+			Text:  text,
+		})
+		ctx.stateLock.Unlock()
+	})()
+
 	return page, nil
+}
+
+// ConsoleMessages returns captured console messages, optionally filtered by level.
+// If clear is true, the buffer is emptied after returning.
+func (ctx *Context) ConsoleMessages(filterLevel string, clear bool) []ConsoleMessage {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	var result []ConsoleMessage
+	for _, msg := range ctx.consoleMessages {
+		if filterLevel == "" || msg.Level == filterLevel {
+			result = append(result, msg)
+		}
+	}
+
+	if clear {
+		if filterLevel == "" {
+			ctx.consoleMessages = nil
+		} else {
+			// Only clear matching messages
+			var remaining []ConsoleMessage
+			for _, msg := range ctx.consoleMessages {
+				if msg.Level != filterLevel {
+					remaining = append(remaining, msg)
+				}
+			}
+			ctx.consoleMessages = remaining
+		}
+	}
+
+	return result
 }
 
 // TabInfo represents a tab's metadata for listing.


### PR DESCRIPTION
## Summary
- Add `rod_console_messages` tool to retrieve captured browser console messages
- Console messages (log, warn, error, info) are buffered automatically via `proto.RuntimeConsoleAPICalled` event listener on page creation
- Optional `level` filter to return only specific message types
- Optional `clear` flag to empty the buffer after retrieval
- `ConsoleMessage` type and buffer management added to `types/Context`

Closes #12