### PR TITLE
feat: add rod_file_upload tool

### DIFF
--- a/tools/common.go
+++ b/tools/common.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
+	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/input"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -122,6 +123,7 @@ const (
 	TabCloseToolKey      = "rod_tab_close"
 	WaitForToolKey          = "rod_wait_for"
 	ConsoleMessagesToolKey  = "rod_console_messages"
+	FileUploadToolKey       = "rod_file_upload"
 )
 
 var (
@@ -202,6 +204,12 @@ var (
 		mcp.WithDescription("Return captured browser console messages (log, warn, error, info)"),
 		mcp.WithString("level", mcp.Description("Filter by level: log, warn, error, info (returns all if not specified)")),
 		mcp.WithBoolean("clear", mcp.Description("Clear captured messages after returning (default: false)")),
+	)
+	FileUpload = mcp.NewTool(FileUploadToolKey,
+		mcp.WithDescription("Upload file(s) to a file input element"),
+		mcp.WithString("selector", mcp.Description("CSS selector of the file input element")),
+		mcp.WithString("ref", mcp.Description("Element reference from the page snapshot")),
+		mcp.WithArray("paths", mcp.Description("File paths to upload"), mcp.Items(map[string]interface{}{"type": "string"}), mcp.Required()),
 	)
 )
 
@@ -630,6 +638,54 @@ var (
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
+	FileUploadHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			selector, _ := request.Params.Arguments["selector"].(string)
+			ref, _ := request.Params.Arguments["ref"].(string)
+
+			if selector == "" && ref == "" {
+				return nil, errors.New("either 'selector' or 'ref' is required")
+			}
+
+			paths, err := utils.OptionalStringArrayParam(request, "paths")
+			if err != nil {
+				return toolErr("parse file paths", err)
+			}
+			if len(paths) == 0 {
+				return nil, errors.New("at least one file path is required")
+			}
+
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("upload files", err)
+			}
+
+			var element *rod.Element
+			if ref != "" {
+				snapshot, err := rodCtx.LatestSnapshot()
+				if err != nil {
+					return toolErr("upload files", err)
+				}
+				element, err = snapshot.LocatorInFrame(ref)
+				if err != nil {
+					return toolErr("upload files", err)
+				}
+			} else {
+				element, err = page.Element(selector)
+				if err != nil {
+					return toolErr("find file input "+selector, err)
+				}
+			}
+
+			if err = element.SetFiles(paths); err != nil {
+				return toolErr("upload files", err)
+			}
+
+			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
+			return mcp.NewToolResultText(fmt.Sprintf("Uploaded %d file(s) successfully", len(paths))), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
 )
 
 var (
@@ -652,6 +708,7 @@ var (
 		TabClose,
 		WaitFor,
 		ConsoleMessages,
+		FileUpload,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		NavigationToolKey:   NavigationHandler,
@@ -672,5 +729,6 @@ var (
 		TabCloseToolKey:     TabCloseHandler,
 		WaitForToolKey:         WaitForHandler,
 		ConsoleMessagesToolKey: ConsoleMessagesHandler,
+		FileUploadToolKey:      FileUploadHandler,
 	}
 )


### PR DESCRIPTION
## Summary
- Add `rod_file_upload` tool to set files on `<input type="file">` elements
- Supports targeting via CSS `selector` or snapshot `ref` (one required)
- Uses rod's `element.SetFiles()` which maps to `DOM.setFileInputFiles` CDP method
- Accepts an array of file paths for single or multi-file uploads

Closes #14