### PR TITLE
feat: implement Vision mode

### DIFF
--- a/server.go
+++ b/server.go
@@ -25,8 +25,7 @@ func NewServer(stdCtx context.Context, cfg types.Config) *Server {
 	case types.Text:
 		ser.registerTools(tools.TextTools, tools.TextToolHandlers)
 	case types.Vision:
-		log.Warn("Vision mode is not yet implemented, falling back to Text mode")
-		ser.registerTools(tools.TextTools, tools.TextToolHandlers)
+		ser.registerTools(tools.VisionTools, tools.VisionCombinedHandlers)
 	}
 	return ser
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -21,4 +21,7 @@ func toolError(action string, err error) error {
 var (
 	TextTools        = append(CommonTools, Snapshots...)
 	TextToolHandlers = utils.MergeMaps(CommonToolHandlers, SnapshotToolHandlers)
+
+	VisionTools            = append(CommonTools, VisionToolDefs...)
+	VisionCombinedHandlers = utils.MergeMaps(CommonToolHandlers, VisionToolHandlers)
 )

--- a/tools/vision.go
+++ b/tools/vision.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-rod/rod/lib/input"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	VisionClickToolKey = "rod_vision_click"
+	VisionFillToolKey  = "rod_vision_fill"
+)
+
+var (
+	VisionClick = mcp.NewTool(VisionClickToolKey,
+		mcp.WithDescription("Click at x,y coordinates on the page (use with screenshots to identify positions)"),
+		mcp.WithNumber("x", mcp.Description("X coordinate in pixels"), mcp.Required()),
+		mcp.WithNumber("y", mcp.Description("Y coordinate in pixels"), mcp.Required()),
+	)
+
+	VisionFill = mcp.NewTool(VisionFillToolKey,
+		mcp.WithDescription("Click at x,y coordinates and type text (use with screenshots to identify input positions)"),
+		mcp.WithNumber("x", mcp.Description("X coordinate in pixels"), mcp.Required()),
+		mcp.WithNumber("y", mcp.Description("Y coordinate in pixels"), mcp.Required()),
+		mcp.WithString("text", mcp.Description("Text to type after clicking"), mcp.Required()),
+		mcp.WithBoolean("submit", mcp.Description("Whether to press Enter after typing (default: false)")),
+	)
+)
+
+var (
+	VisionClickHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("vision click", err)
+			}
+
+			x := request.Params.Arguments["x"].(float64)
+			y := request.Params.Arguments["y"].(float64)
+
+			if err = page.Mouse.MoveTo(proto.Point{X: x, Y: y}); err != nil {
+				return toolErr(fmt.Sprintf("vision click move to (%.0f, %.0f)", x, y), err)
+			}
+			if err = page.Mouse.Click(proto.InputMouseButtonLeft, 1); err != nil {
+				return toolErr(fmt.Sprintf("vision click at (%.0f, %.0f)", x, y), err)
+			}
+
+			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
+			return mcp.NewToolResultText(fmt.Sprintf("Clicked at (%.0f, %.0f) successfully", x, y)), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+
+	VisionFillHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("vision fill", err)
+			}
+
+			x := request.Params.Arguments["x"].(float64)
+			y := request.Params.Arguments["y"].(float64)
+			text := request.Params.Arguments["text"].(string)
+
+			// Click to focus the input
+			if err = page.Mouse.MoveTo(proto.Point{X: x, Y: y}); err != nil {
+				return toolErr(fmt.Sprintf("vision fill move to (%.0f, %.0f)", x, y), err)
+			}
+			if err = page.Mouse.Click(proto.InputMouseButtonLeft, 1); err != nil {
+				return toolErr(fmt.Sprintf("vision fill click at (%.0f, %.0f)", x, y), err)
+			}
+
+			// Type the text
+			if err = page.InsertText(text); err != nil {
+				return toolErr("vision fill type text", err)
+			}
+
+			if submit, ok := request.Params.Arguments["submit"].(bool); ok && submit {
+				if err = page.Keyboard.Press(input.Enter); err != nil {
+					return toolErr("vision fill submit", err)
+				}
+			}
+
+			page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff)
+			return mcp.NewToolResultText(fmt.Sprintf("Filled text at (%.0f, %.0f) successfully", x, y)), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)
+
+var (
+	VisionToolHandlers = map[string]ToolHandler{
+		VisionClickToolKey: VisionClickHandler,
+		VisionFillToolKey:  VisionFillHandler,
+	}
+	VisionToolDefs = []mcp.Tool{
+		VisionClick,
+		VisionFill,
+	}
+)


### PR DESCRIPTION
## Summary
- Implement Vision mode with coordinate-based interaction tools
- Add `rod_vision_click` — click at x,y coordinates (mouse move + click)
- Add `rod_vision_fill` — click at coordinates, type text, optionally submit
- New `tools/vision.go` with Vision-specific tools and handlers
- Wire up `VisionTools` + `VisionCombinedHandlers` in `tools/tools.go` (common tools + vision tools)
- Update `server.go` to register Vision tools instead of falling back to Text mode

Vision mode is designed for screenshot-based LLM interaction where the model identifies click targets from screenshots rather than accessibility snapshots.

Closes #18