### PR TITLE
feat: add rod_network_requests tool

### DIFF
--- a/tools/common.go
+++ b/tools/common.go
@@ -124,6 +124,7 @@ const (
 	WaitForToolKey          = "rod_wait_for"
 	ConsoleMessagesToolKey  = "rod_console_messages"
 	FileUploadToolKey       = "rod_file_upload"
+	NetworkRequestsToolKey  = "rod_network_requests"
 )
 
 var (
@@ -210,6 +211,12 @@ var (
 		mcp.WithString("selector", mcp.Description("CSS selector of the file input element")),
 		mcp.WithString("ref", mcp.Description("Element reference from the page snapshot")),
 		mcp.WithArray("paths", mcp.Description("File paths to upload"), mcp.Items(map[string]interface{}{"type": "string"}), mcp.Required()),
+	)
+	NetworkRequests = mcp.NewTool(NetworkRequestsToolKey,
+		mcp.WithDescription("Return captured network requests with method, URL, status code, and resource type"),
+		mcp.WithString("url", mcp.Description("Filter requests by URL substring")),
+		mcp.WithString("method", mcp.Description("Filter by HTTP method: GET, POST, etc.")),
+		mcp.WithBoolean("clear", mcp.Description("Clear captured requests after returning (default: false)")),
 	)
 )
 
@@ -686,6 +693,26 @@ var (
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
+	NetworkRequestsHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			filterURL, _ := request.Params.Arguments["url"].(string)
+			filterMethod, _ := request.Params.Arguments["method"].(string)
+			clear, _ := request.Params.Arguments["clear"].(bool)
+
+			requests := rodCtx.NetworkRequests(filterURL, filterMethod, clear)
+			if len(requests) == 0 {
+				return mcp.NewToolResultText("No network requests captured"), nil
+			}
+
+			var result string
+			for _, req := range requests {
+				result += fmt.Sprintf("%s %s → %d (%s)\n", req.Method, req.URL, req.Status, req.Type)
+			}
+			result += fmt.Sprintf("\nTotal: %d requests", len(requests))
+			return mcp.NewToolResultText(result), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
 )
 
 var (
@@ -709,6 +736,7 @@ var (
 		WaitFor,
 		ConsoleMessages,
 		FileUpload,
+		NetworkRequests,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		NavigationToolKey:   NavigationHandler,
@@ -730,5 +758,6 @@ var (
 		WaitForToolKey:         WaitForHandler,
 		ConsoleMessagesToolKey: ConsoleMessagesHandler,
 		FileUploadToolKey:      FileUploadHandler,
+		NetworkRequestsToolKey: NetworkRequestsHandler,
 	}
 )

--- a/types/context.go
+++ b/types/context.go
@@ -102,6 +102,14 @@ type ConsoleMessage struct {
 	Text  string `json:"text"`
 }
 
+// NetworkRequest represents a captured network request with its response.
+type NetworkRequest struct {
+	Method string `json:"method"`
+	URL    string `json:"url"`
+	Status int    `json:"status"`
+	Type   string `json:"type"`
+}
+
 type Context struct {
 	stdContext       context.Context
 	config          Config
@@ -111,6 +119,9 @@ type Context struct {
 	snapshot        *Snapshot
 	mode            Mode
 	consoleMessages []ConsoleMessage
+	networkRequests []NetworkRequest
+	// pendingRequests tracks in-flight requests by ID for response correlation.
+	pendingRequests map[string]int
 }
 
 func NewContext(ctx context.Context, cfg Config) *Context {
@@ -277,7 +288,7 @@ func (ctx *Context) createPage(urls ...string) (*rod.Page, error) {
 		}
 	}
 
-	// Listen for console messages
+	// Listen for console messages and network events
 	go page.EachEvent(func(e *proto.RuntimeConsoleAPICalled) {
 		var parts []string
 		for _, arg := range e.Args {
@@ -289,6 +300,27 @@ func (ctx *Context) createPage(urls ...string) (*rod.Page, error) {
 			Level: string(e.Type),
 			Text:  text,
 		})
+		ctx.stateLock.Unlock()
+	}, func(e *proto.NetworkRequestWillBeSent) {
+		ctx.stateLock.Lock()
+		if ctx.pendingRequests == nil {
+			ctx.pendingRequests = make(map[string]int)
+		}
+		idx := len(ctx.networkRequests)
+		ctx.networkRequests = append(ctx.networkRequests, NetworkRequest{
+			Method: e.Request.Method,
+			URL:    e.Request.URL,
+			Type:   string(e.Type),
+		})
+		ctx.pendingRequests[string(e.RequestID)] = idx
+		ctx.stateLock.Unlock()
+	}, func(e *proto.NetworkResponseReceived) {
+		ctx.stateLock.Lock()
+		if idx, ok := ctx.pendingRequests[string(e.RequestID)]; ok {
+			ctx.networkRequests[idx].Status = e.Response.Status
+			ctx.networkRequests[idx].Type = string(e.Type)
+			delete(ctx.pendingRequests, string(e.RequestID))
+		}
 		ctx.stateLock.Unlock()
 	})()
 
@@ -321,6 +353,31 @@ func (ctx *Context) ConsoleMessages(filterLevel string, clear bool) []ConsoleMes
 			}
 			ctx.consoleMessages = remaining
 		}
+	}
+
+	return result
+}
+
+// NetworkRequests returns captured network requests, optionally filtered by URL pattern and method.
+// If clear is true, the buffer is emptied after returning.
+func (ctx *Context) NetworkRequests(filterURL, filterMethod string, clear bool) []NetworkRequest {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	var result []NetworkRequest
+	for _, req := range ctx.networkRequests {
+		if filterURL != "" && !strings.Contains(req.URL, filterURL) {
+			continue
+		}
+		if filterMethod != "" && !strings.EqualFold(req.Method, filterMethod) {
+			continue
+		}
+		result = append(result, req)
+	}
+
+	if clear {
+		ctx.networkRequests = nil
+		ctx.pendingRequests = nil
 	}
 
 	return result


### PR DESCRIPTION
## Summary
- Add `rod_network_requests` tool to capture and inspect network requests/responses
- Network events buffered via `proto.NetworkRequestWillBeSent` and `proto.NetworkResponseReceived` listeners
- Requests and responses correlated by request ID in `pendingRequests` map
- `NetworkRequest` type captures method, URL, status code, and resource type
- Optional `url` (substring match) and `method` filters
- Optional `clear` flag to empty the buffer after retrieval

Closes #11