### PR TITLE
fix: ignore SSL certificate errors for self-signed certs

### DIFF
--- a/types/context.go
+++ b/types/context.go
@@ -36,7 +36,7 @@ func launchBrowser(ctx context.Context, cfg Config) (*rod.Browser, error) {
 		NoSandbox(cfg.NoSandbox).
 		Set("no-gpu").
 		Set("--no-first-run").
-		Set("ignore-certificate-errors", "true").
+		Set("ignore-certificate-errors").
 		Set("disable-xss-auditor", "true").
 		Set("disable-popup-blocking").
 		Set("mute-audio", "true").
@@ -81,6 +81,9 @@ func controlBrowser(ctx context.Context, controlURL string) (*rod.Browser, error
 			return nil, errors.Wrap(err, "in connect browser stage to close browser happened err")
 		}
 		return nil, errors.Wrap(err, "Error connecting to browser")
+	}
+	if err := browser.IgnoreCertErrors(true); err != nil {
+		return nil, errors.Wrap(err, "failed to set ignore certificate errors")
 	}
 	return browser, nil
 }


### PR DESCRIPTION
## Summary

- Fix Chrome's `ignore-certificate-errors` launch flag — was passing unnecessary `"true"` value for a boolean flag, producing `--ignore-certificate-errors=true` instead of `--ignore-certificate-errors`
- Add CDP-level `browser.IgnoreCertErrors(true)` call after browser connection for reliable certificate error bypassing (equivalent to Playwright's `ignoreHTTPSErrors: true`)
- Fixes "Connection closed" errors when navigating to local `.test` domains with self-signed certificates (e.g., mkcert)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: navigate to `https://www.travelblog.test/` — should load without "Connection closed" error

Closes aliwatters/dotfiles#7519