### PR TITLE
fix: bug fixes and error handling safety

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -7,18 +7,12 @@ import (
 )
 
 type Runner struct {
-	ctx    context.Context
-	rodCtx *types.Context
 	server *Server
 }
 
 func NewRunner(ctx context.Context, cfg types.Config) *Runner {
-	rodCtx := types.NewContext(ctx, cfg)
-	server := NewServer(ctx, cfg)
 	return &Runner{
-		ctx:    ctx,
-		rodCtx: rodCtx,
-		server: server,
+		server: NewServer(ctx, cfg),
 	}
 }
 

--- a/tools/args.go
+++ b/tools/args.go
@@ -1,0 +1,51 @@
+package tools
+
+import "fmt"
+
+// getStringArg extracts a required string argument from the MCP request.
+func getStringArg(args map[string]interface{}, key string) (string, error) {
+	v, ok := args[key]
+	if !ok {
+		return "", fmt.Errorf("missing required argument: %s", key)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("argument %s must be a string, got %T", key, v)
+	}
+	return s, nil
+}
+
+// getFloatArg extracts a required float64 argument from the MCP request.
+func getFloatArg(args map[string]interface{}, key string) (float64, error) {
+	v, ok := args[key]
+	if !ok {
+		return 0, fmt.Errorf("missing required argument: %s", key)
+	}
+	f, ok := v.(float64)
+	if !ok {
+		return 0, fmt.Errorf("argument %s must be a number, got %T", key, v)
+	}
+	return f, nil
+}
+
+// getOptionalStringArg extracts an optional string argument, returning "" if not present.
+func getOptionalStringArg(args map[string]interface{}, key string) string {
+	v, _ := args[key].(string)
+	return v
+}
+
+// getOptionalFloatArg extracts an optional float64 argument, returning the fallback if not present.
+func getOptionalFloatArg(args map[string]interface{}, key string, fallback float64) float64 {
+	if v, ok := args[key].(float64); ok {
+		return v
+	}
+	return fallback
+}
+
+// getOptionalBoolArg extracts an optional bool argument, returning the fallback if not present.
+func getOptionalBoolArg(args map[string]interface{}, key string, fallback bool) bool {
+	if v, ok := args[key].(bool); ok {
+		return v
+	}
+	return fallback
+}

--- a/tools/args_test.go
+++ b/tools/args_test.go
@@ -1,0 +1,116 @@
+package tools
+
+import "testing"
+
+func TestGetStringArg(t *testing.T) {
+	args := map[string]interface{}{
+		"name":  "hello",
+		"count": 42.0,
+	}
+
+	tests := []struct {
+		name    string
+		key     string
+		want    string
+		wantErr bool
+	}{
+		{"present string", "name", "hello", false},
+		{"missing key", "missing", "", true},
+		{"wrong type", "count", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getStringArg(args, tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getStringArg(%q) error = %v, wantErr %v", tt.key, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getStringArg(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetFloatArg(t *testing.T) {
+	args := map[string]interface{}{
+		"x":    42.5,
+		"name": "hello",
+	}
+
+	tests := []struct {
+		name    string
+		key     string
+		want    float64
+		wantErr bool
+	}{
+		{"present float", "x", 42.5, false},
+		{"missing key", "missing", 0, true},
+		{"wrong type", "name", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getFloatArg(args, tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getFloatArg(%q) error = %v, wantErr %v", tt.key, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getFloatArg(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetOptionalStringArg(t *testing.T) {
+	args := map[string]interface{}{
+		"name":  "hello",
+		"count": 42.0,
+	}
+
+	if got := getOptionalStringArg(args, "name"); got != "hello" {
+		t.Errorf("getOptionalStringArg(name) = %q, want %q", got, "hello")
+	}
+	if got := getOptionalStringArg(args, "missing"); got != "" {
+		t.Errorf("getOptionalStringArg(missing) = %q, want empty", got)
+	}
+	if got := getOptionalStringArg(args, "count"); got != "" {
+		t.Errorf("getOptionalStringArg(count) = %q, want empty (wrong type)", got)
+	}
+}
+
+func TestGetOptionalFloatArg(t *testing.T) {
+	args := map[string]interface{}{
+		"x":    42.5,
+		"name": "hello",
+	}
+
+	if got := getOptionalFloatArg(args, "x", 0); got != 42.5 {
+		t.Errorf("getOptionalFloatArg(x) = %v, want 42.5", got)
+	}
+	if got := getOptionalFloatArg(args, "missing", 99.0); got != 99.0 {
+		t.Errorf("getOptionalFloatArg(missing) = %v, want 99.0", got)
+	}
+	if got := getOptionalFloatArg(args, "name", 99.0); got != 99.0 {
+		t.Errorf("getOptionalFloatArg(name) = %v, want 99.0 (wrong type)", got)
+	}
+}
+
+func TestGetOptionalBoolArg(t *testing.T) {
+	args := map[string]interface{}{
+		"flag": true,
+		"name": "hello",
+	}
+
+	if got := getOptionalBoolArg(args, "flag", false); got != true {
+		t.Errorf("getOptionalBoolArg(flag) = %v, want true", got)
+	}
+	if got := getOptionalBoolArg(args, "missing", false); got != false {
+		t.Errorf("getOptionalBoolArg(missing) = %v, want false", got)
+	}
+	if got := getOptionalBoolArg(args, "name", false); got != false {
+		t.Errorf("getOptionalBoolArg(name) = %v, want false (wrong type)", got)
+	}
+}

--- a/tools/common.go
+++ b/tools/common.go
@@ -223,7 +223,10 @@ var (
 var (
 	NavigationHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			url := request.Params.Arguments["url"].(string)
+			url, err := getStringArg(request.Params.Arguments, "url")
+			if err != nil {
+				return toolErr("navigate", err)
+			}
 			if !utils.IsHttp(url) {
 				return nil, toolError("navigate", fmt.Errorf("invalid URL: %s", url))
 			}
@@ -298,7 +301,10 @@ var (
 			if err != nil {
 				return toolErr("press key", err)
 			}
-			keyStr := request.Params.Arguments["key"].(string)
+			keyStr, err := getStringArg(request.Params.Arguments, "key")
+			if err != nil {
+				return toolErr("press key", err)
+			}
 			key, err := parseKey(keyStr)
 			if err != nil {
 				return toolErr("parse key "+keyStr, err)
@@ -326,7 +332,10 @@ var (
 			if err != nil {
 				return toolErr("evaluate", err)
 			}
-			script := request.Params.Arguments["script"].(string)
+			script, err := getStringArg(request.Params.Arguments, "script")
+			if err != nil {
+				return toolErr("evaluate", err)
+			}
 			r, err := proto.RuntimeEvaluate{
 				Expression:            script,
 				ObjectGroup:           "console",
@@ -352,7 +361,10 @@ var (
 			if err != nil {
 				return toolErr("capture screenshot", err)
 			}
-			name := request.Params.Arguments["name"].(string)
+			name, err := getStringArg(request.Params.Arguments, "name")
+			if err != nil {
+				return toolErr("screenshot", err)
+			}
 
 			// Always save to file
 			cfg := rodCtx.Config()
@@ -387,7 +399,10 @@ var (
 			if err != nil {
 				return toolErr("read PDF data", err)
 			}
-			name := request.Params.Arguments["name"].(string)
+			name, err := getStringArg(request.Params.Arguments, "name")
+			if err != nil {
+				return toolErr("generate PDF", err)
+			}
 
 			// Always save to file, never return inline (PDFs can't be rendered inline by MCP clients)
 			cfg := rodCtx.Config()
@@ -427,18 +442,19 @@ var (
 			if err != nil {
 				return toolErr("resize viewport", err)
 			}
-			width := int(request.Params.Arguments["width"].(float64))
-			height := int(request.Params.Arguments["height"].(float64))
-
-			deviceScaleFactor := 1.0
-			if dsf, ok := request.Params.Arguments["device_scale_factor"].(float64); ok {
-				deviceScaleFactor = dsf
+			widthF, err := getFloatArg(request.Params.Arguments, "width")
+			if err != nil {
+				return toolErr("resize viewport", err)
 			}
-
-			mobile := false
-			if m, ok := request.Params.Arguments["is_mobile"].(bool); ok {
-				mobile = m
+			heightF, err := getFloatArg(request.Params.Arguments, "height")
+			if err != nil {
+				return toolErr("resize viewport", err)
 			}
+			width := int(widthF)
+			height := int(heightF)
+
+			deviceScaleFactor := getOptionalFloatArg(request.Params.Arguments, "device_scale_factor", 1.0)
+			mobile := getOptionalBoolArg(request.Params.Arguments, "is_mobile", false)
 
 			err = proto.EmulationSetDeviceMetricsOverride{
 				Width:             width,
@@ -460,7 +476,10 @@ var (
 				return toolErr("handle dialog", err)
 			}
 
-			action := request.Params.Arguments["action"].(string)
+			action, err := getStringArg(request.Params.Arguments, "action")
+			if err != nil {
+				return toolErr("handle dialog", err)
+			}
 			if action != "accept" && action != "dismiss" {
 				return nil, errors.New("action must be 'accept' or 'dismiss'")
 			}
@@ -521,7 +540,11 @@ var (
 	}
 	TabSelectHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			index := int(request.Params.Arguments["index"].(float64))
+			indexF, err := getFloatArg(request.Params.Arguments, "index")
+			if err != nil {
+				return toolErr("select tab", err)
+			}
+			index := int(indexF)
 			page, err := rodCtx.SelectTab(index)
 			if err != nil {
 				return toolErr("select tab", err)
@@ -536,7 +559,11 @@ var (
 	}
 	TabCloseHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			index := int(request.Params.Arguments["index"].(float64))
+			indexF, err := getFloatArg(request.Params.Arguments, "index")
+			if err != nil {
+				return toolErr("close tab", err)
+			}
+			index := int(indexF)
 			if err := rodCtx.CloseTab(index); err != nil {
 				return toolErr("close tab", err)
 			}

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -69,7 +69,10 @@ var (
 
 	ClickHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			ele := request.Params.Arguments["element"].(string)
+			ele, err := getStringArg(request.Params.Arguments, "element")
+			if err != nil {
+				return toolErr("click element", err)
+			}
 			page, err := rodCtx.ControlledPage()
 			if err != nil {
 				return toolErr("click element "+ele, err)
@@ -80,7 +83,10 @@ var (
 				return toolErr("click element "+ele, err)
 			}
 
-			ref := request.Params.Arguments["ref"].(string)
+			ref, err := getStringArg(request.Params.Arguments, "ref")
+			if err != nil {
+				return toolErr("click element "+ele, err)
+			}
 			element, err := snapshot.LocatorInFrame(ref)
 			if err != nil {
 				return toolErr("click element "+ele, err)
@@ -97,7 +103,10 @@ var (
 
 	HoverHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			ele := request.Params.Arguments["element"].(string)
+			ele, err := getStringArg(request.Params.Arguments, "element")
+			if err != nil {
+				return toolErr("hover element", err)
+			}
 			page, err := rodCtx.ControlledPage()
 			if err != nil {
 				return toolErr("hover element "+ele, err)
@@ -108,7 +117,10 @@ var (
 				return toolErr("hover element "+ele, err)
 			}
 
-			ref := request.Params.Arguments["ref"].(string)
+			ref, err := getStringArg(request.Params.Arguments, "ref")
+			if err != nil {
+				return toolErr("hover element "+ele, err)
+			}
 			element, err := snapshot.LocatorInFrame(ref)
 			if err != nil {
 				return toolErr("hover element "+ele, err)
@@ -125,7 +137,10 @@ var (
 
 	FillHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			ele := request.Params.Arguments["element"].(string)
+			ele, err := getStringArg(request.Params.Arguments, "element")
+			if err != nil {
+				return toolErr("fill element", err)
+			}
 			page, err := rodCtx.ControlledPage()
 			if err != nil {
 				return toolErr("fill element "+ele, err)
@@ -136,13 +151,19 @@ var (
 				return toolErr("fill element "+ele, err)
 			}
 
-			ref := request.Params.Arguments["ref"].(string)
+			ref, err := getStringArg(request.Params.Arguments, "ref")
+			if err != nil {
+				return toolErr("fill element "+ele, err)
+			}
 			element, err := snapshot.LocatorInFrame(ref)
 			if err != nil {
 				return toolErr("fill element "+ele, err)
 			}
 
-			value := request.Params.Arguments["value"].(string)
+			value, err := getStringArg(request.Params.Arguments, "value")
+			if err != nil {
+				return toolErr("fill element "+ele, err)
+			}
 			// Clear existing value by selecting all text first, then input new value
 			// This ensures password fields and React-controlled inputs work correctly
 			if err = element.SelectAllText(); err != nil {
@@ -166,7 +187,10 @@ var (
 
 	SelectorHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			ele := request.Params.Arguments["element"].(string)
+			ele, err := getStringArg(request.Params.Arguments, "element")
+			if err != nil {
+				return toolErr("select option", err)
+			}
 			page, err := rodCtx.ControlledPage()
 			if err != nil {
 				return toolErr("select option in element "+ele, err)
@@ -177,7 +201,10 @@ var (
 				return toolErr("select option in element "+ele, err)
 			}
 
-			ref := request.Params.Arguments["ref"].(string)
+			ref, err := getStringArg(request.Params.Arguments, "ref")
+			if err != nil {
+				return toolErr("select option in element "+ele, err)
+			}
 			element, err := snapshot.LocatorInFrame(ref)
 			if err != nil {
 				return toolErr("select option in element "+ele, err)

--- a/tools/vision.go
+++ b/tools/vision.go
@@ -41,8 +41,14 @@ var (
 				return toolErr("vision click", err)
 			}
 
-			x := request.Params.Arguments["x"].(float64)
-			y := request.Params.Arguments["y"].(float64)
+			x, err := getFloatArg(request.Params.Arguments, "x")
+			if err != nil {
+				return toolErr("vision click", err)
+			}
+			y, err := getFloatArg(request.Params.Arguments, "y")
+			if err != nil {
+				return toolErr("vision click", err)
+			}
 
 			if err = page.Mouse.MoveTo(proto.Point{X: x, Y: y}); err != nil {
 				return toolErr(fmt.Sprintf("vision click move to (%.0f, %.0f)", x, y), err)
@@ -64,9 +70,18 @@ var (
 				return toolErr("vision fill", err)
 			}
 
-			x := request.Params.Arguments["x"].(float64)
-			y := request.Params.Arguments["y"].(float64)
-			text := request.Params.Arguments["text"].(string)
+			x, err := getFloatArg(request.Params.Arguments, "x")
+			if err != nil {
+				return toolErr("vision fill", err)
+			}
+			y, err := getFloatArg(request.Params.Arguments, "y")
+			if err != nil {
+				return toolErr("vision fill", err)
+			}
+			text, err := getStringArg(request.Params.Arguments, "text")
+			if err != nil {
+				return toolErr("vision fill", err)
+			}
 
 			// Click to focus the input
 			if err = page.Mouse.MoveTo(proto.Point{X: x, Y: y}); err != nil {

--- a/types/config.go
+++ b/types/config.go
@@ -1,12 +1,14 @@
 package types
 
 import (
-	"github.com/aliwatters/rod-mcp/utils"
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/aliwatters/rod-mcp/utils"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
 )
 
 const ConfigName = "rod-mcp.yaml"
@@ -105,26 +107,28 @@ func LoadConfig(configPath string) (*Config, error) {
 		return nil, errors.Wrap(err, "could not open config file")
 	}
 
-	if exist {
-		// validate config file name
-		fileName := utils.FileName(configPath)
-		if strings.Contains(ConfigName, fileName) {
-			file, err := os.Open(configPath)
-			if err != nil {
-				return nil, err
-			}
-			defer file.Close()
-
-			decoder := yaml.NewDecoder(file)
-			var config Config
-			if err := decoder.Decode(&config); err != nil {
-				return nil, err
-			}
-			return &config, nil
-		}
-		return nil, errors.Wrapf(err, "config file name is wrong")
+	if !exist {
+		return nil, fmt.Errorf("config path %s not found", configPath)
 	}
-	return nil, errors.Wrapf(err, "config path %s not found", configPath)
+
+	// validate config file name
+	fileName := utils.FileName(configPath)
+	if fileName != ConfigName {
+		return nil, fmt.Errorf("config file name is wrong: expected %s, got %s", ConfigName, fileName)
+	}
+
+	file, err := os.Open(configPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	var config Config
+	if err := decoder.Decode(&config); err != nil {
+		return nil, err
+	}
+	return &config, nil
 }
 
 // GetHeadersForURL returns all headers that should be applied for the given URL.

--- a/types/context.go
+++ b/types/context.go
@@ -76,11 +76,11 @@ func controlBrowser(ctx context.Context, controlURL string) (*rod.Browser, error
 	browser := rod.New().Context(ctx)
 	err := browser.ControlURL(controlURL).Connect()
 	if err != nil {
-		err := browser.Close()
-		if err != nil {
-			return nil, errors.Wrap(err, "in connect browser stage to close browser happened err")
+		closeErr := browser.Close()
+		if closeErr != nil {
+			return nil, errors.Wrap(closeErr, "close browser after connect failure")
 		}
-		return nil, errors.Wrap(err, "Error connecting to browser")
+		return nil, errors.Wrap(err, "error connecting to browser")
 	}
 	return browser, nil
 }
@@ -171,7 +171,7 @@ func (ctx *Context) initial() error {
 		}
 	}
 
-	return err
+	return nil
 
 }
 
@@ -252,7 +252,7 @@ func (ctx *Context) closePage() error {
 		return errors.Wrap(err, "close page failed")
 	}
 	ctx.page = nil
-	return err
+	return nil
 }
 func (ctx *Context) closeBrowser() error {
 	err := ctx.closePage()
@@ -275,9 +275,11 @@ func (ctx *Context) closeBrowser() error {
 func (ctx *Context) createPage(urls ...string) (*rod.Page, error) {
 	targetURL := strings.Join(urls, "/")
 	page, err := ctx.browser.Page(proto.TargetCreateTarget{URL: targetURL})
-	page.EvalOnNewDocument(js.InjectedSnapShot)
 	if err != nil {
 		return nil, errors.Wrap(err, "create page failed")
+	}
+	if _, err := page.EvalOnNewDocument(js.InjectedSnapShot); err != nil {
+		return nil, errors.Wrap(err, "inject snapshot script failed")
 	}
 
 	// Apply HTTP headers from config (global + domain-specific)
@@ -529,7 +531,9 @@ func (ctx *Context) UpdateHeadersForURL(url string) error {
 func (ctx *Context) Close() error {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-	ctx.closeBrowser()
+	if err := ctx.closeBrowser(); err != nil {
+		log.Warnf("close browser: %s", err)
+	}
 
 	// remove browser temp dir
 	if ctx.config.BrowserTempDir != "" && ctx.config.CDPEndpoint == "" {

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -356,6 +356,9 @@ func truncateScalar(value string, maxLen int) string {
 }
 
 func (s *Snapshot) LocatorInFrame(ref string) (*rod.Element, error) {
+	if len(s.frames) == 0 {
+		return nil, errors.New("no frames available in snapshot")
+	}
 	frame := s.frames[0]
 	matches := regexp.MustCompile(`^f(\d+)(.*)`).FindStringSubmatch(ref)
 	if len(matches) > 0 {
@@ -364,8 +367,8 @@ func (s *Snapshot) LocatorInFrame(ref string) (*rod.Element, error) {
 			return nil, errors.Wrapf(err, "locator frame failed, because of frame index is not number")
 		}
 
-		if frameIndex < 0 || frameIndex > len(s.frames) {
-			return nil, errors.Errorf("locator frame failed, because of frame index is out of range")
+		if frameIndex < 0 || frameIndex >= len(s.frames) {
+			return nil, errors.Errorf("frame index %d out of range (0-%d)", frameIndex, len(s.frames)-1)
 		}
 		frame = s.frames[frameIndex]
 		ref = matches[2]

--- a/types/snapshot_test.go
+++ b/types/snapshot_test.go
@@ -1,0 +1,22 @@
+package types
+
+import "testing"
+
+func TestLocatorInFrame_BoundsCheck(t *testing.T) {
+	// Create a snapshot with one frame (index 0)
+	s := &Snapshot{
+		frames: nil, // empty frames slice
+	}
+
+	// Any frame reference should fail on empty snapshot
+	_, err := s.LocatorInFrame("f0e1")
+	if err == nil {
+		t.Error("LocatorInFrame with frameIndex=0 on empty frames should return error")
+	}
+
+	// Test with non-existent frame index that would pass with > but fail with >=
+	_, err = s.LocatorInFrame("f1e1")
+	if err == nil {
+		t.Error("LocatorInFrame with frameIndex=1 on empty frames should return error")
+	}
+}


### PR DESCRIPTION
## Summary

Bundled bug fixes and error handling improvements from epic #59.

**6 issues resolved:**

### Critical Bug Fixes
- **#49** — `controlBrowser` variable shadowing returned `nil, nil` on connect failure (appeared successful despite failing)
- **#50** — `createPage` used `page` before nil check (nil pointer dereference risk) and silently discarded `EvalOnNewDocument` error

### Boundary & Validation Bugs
- **#51** — `LocatorInFrame` off-by-one: `>` should be `>=` (index-out-of-range panic). Also added guard for empty frames slice.
- **#52** — `LoadConfig` filename validation was backwards (`Contains(constant, input)` matched substrings like "rod" or ".") and `errors.Wrapf(nil, ...)` returned nil on error paths

### Dead Code & Resource Leak
- **#53** — `Runner` struct had unused `ctx` and `rodCtx` fields; `NewRunner` created a duplicate `types.Context` that was never used or cleaned up

### Defensive Coding
- **#54** — ~20 bare type assertions (`args["key"].(string)`) replaced with safe helpers that return errors instead of panicking on malformed MCP requests

### Additional Fixes (discovered during implementation)
- `closePage()` returned `err` instead of `nil` on success path
- `initial()` returned uninitialized `err` variable
- `Close()` silently discarded `closeBrowser()` error — now logs it

## Changes
- `types/context.go` — Fixed `controlBrowser`, `createPage`, `closePage`, `initial`, `Close`
- `types/snapshot.go` — Fixed `LocatorInFrame` bounds check + empty frames guard
- `types/config.go` — Fixed `LoadConfig` validation and error wrapping
- `runner.go` — Removed unused fields and duplicate Context
- `tools/common.go` — Replaced bare type assertions with safe helpers
- `tools/snapshot.go` — Replaced bare type assertions with safe helpers
- `tools/vision.go` — Replaced bare type assertions with safe helpers
- `tools/args.go` — New: safe argument extraction helpers
- `tools/args_test.go` — New: tests for argument helpers
- `types/snapshot_test.go` — New: tests for LocatorInFrame bounds

## Testing
- All existing tests pass
- New tests for argument extraction helpers (5 test functions, 15 test cases)
- New tests for LocatorInFrame boundary conditions

Fixes #49, fixes #50, fixes #51, fixes #52, fixes #53, fixes #54