### PR TITLE
fix: LoadConfig merges defaults and accepts custom filenames

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -111,12 +111,6 @@ func LoadConfig(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("config path %s not found", configPath)
 	}
 
-	// validate config file name
-	fileName := utils.FileName(configPath)
-	if fileName != ConfigName {
-		return nil, fmt.Errorf("config file name is wrong: expected %s, got %s", ConfigName, fileName)
-	}
-
 	file, err := os.Open(configPath)
 	if err != nil {
 		return nil, err
@@ -124,7 +118,7 @@ func LoadConfig(configPath string) (*Config, error) {
 	defer file.Close()
 
 	decoder := yaml.NewDecoder(file)
-	var config Config
+	config := DefaultConfig
 	if err := decoder.Decode(&config); err != nil {
 		return nil, err
 	}

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -1,6 +1,50 @@
 package types
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigMergesDefaults(t *testing.T) {
+	// Write a minimal config with only mode set
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "minimal.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: vision\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.ServerName != DefaultServerName {
+		t.Errorf("ServerName = %q, want %q (from DefaultConfig)", cfg.ServerName, DefaultServerName)
+	}
+	if cfg.Mode != Vision {
+		t.Errorf("Mode = %q, want %q (from YAML)", cfg.Mode, Vision)
+	}
+	if cfg.ImageResponses != ImageResponsesAllow {
+		t.Errorf("ImageResponses = %q, want %q (from DefaultConfig)", cfg.ImageResponses, ImageResponsesAllow)
+	}
+}
+
+func TestLoadConfigAcceptsCustomFilename(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "my-custom-config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: text\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig should accept custom filename, got: %v", err)
+	}
+	if cfg.Mode != Text {
+		t.Errorf("Mode = %q, want %q", cfg.Mode, Text)
+	}
+}
 
 func TestMatchDomainPattern(t *testing.T) {
 	tests := []struct {

--- a/utils/file.go
+++ b/utils/file.go
@@ -1,9 +1,6 @@
 package utils
 
-import (
-	"os"
-	"path/filepath"
-)
+import "os"
 
 func PathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
@@ -14,12 +11,4 @@ func PathExists(path string) (bool, error) {
 		return false, nil
 	}
 	return false, err
-}
-
-func FileName(path string) string {
-	_, file := filepath.Split(path)
-	if file != "" {
-		return file
-	}
-	return ""
 }


### PR DESCRIPTION
## Summary
- **#66**: `LoadConfig` now initializes from `DefaultConfig` before YAML decode, so missing fields retain defaults (e.g. `ServerName`, `ImageResponses`) instead of Go zero values
- **#67**: Removed filename validation that rejected custom config paths via `-c` flag — any valid YAML file is now accepted regardless of its name
- Removed unused `utils.FileName` function

## Test plan
- [x] `TestLoadConfigMergesDefaults` — minimal YAML retains `DefaultConfig` values
- [x] `TestLoadConfigAcceptsCustomFilename` — custom filename accepted without error
- [x] All existing tests pass (36/36)

Fixes #66, fixes #67