### PR TITLE
feat: add rod_configure tool to consolidate MCP server variants

### DIFF
--- a/mcp-registry.json
+++ b/mcp-registry.json
@@ -1,0 +1,9 @@
+{
+  "rod-mcp": {
+    "command": "~/.local/libexec/rod-mcp",
+    "args": ["--headless", "--no-banner", "--compact-snapshot", "--config", "~/.config/rod-mcp/rod-mcp.yaml"],
+    "description": "Browser automation with Rod: headless, GUI, or authenticated Chrome sessions. Use rod_configure to switch modes.",
+    "keywords": ["browser", "headless", "gui", "auth", "scrape", "web", "automation", "rod", "navigate"],
+    "category": "browser"
+  }
+}

--- a/tools/configure.go
+++ b/tools/configure.go
@@ -1,0 +1,57 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const ConfigureToolKey = "rod_configure"
+
+var Configure = mcp.NewTool(ConfigureToolKey,
+	mcp.WithDescription("Configure browser settings. If the browser is already running it will be closed and restarted with the new settings on the next tool call."),
+	mcp.WithBoolean("headless", mcp.Description("Run the browser in headless mode (true) or with a visible GUI (false)")),
+	mcp.WithString("cdp_endpoint", mcp.Description("Connect to an existing Chrome instance via CDP endpoint URL (e.g. http://127.0.0.1:9222)")),
+)
+
+var ConfigureHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.Params.Arguments
+
+		var headless *bool
+		if v, ok := args["headless"].(bool); ok {
+			headless = &v
+		}
+
+		var cdpEndpoint *string
+		if v, ok := args["cdp_endpoint"].(string); ok {
+			cdpEndpoint = &v
+		}
+
+		if err := rodCtx.Reconfigure(headless, cdpEndpoint); err != nil {
+			return toolErr("configure browser", err)
+		}
+
+		var parts []string
+		if headless != nil {
+			parts = append(parts, fmt.Sprintf("headless=%t", *headless))
+		}
+		if cdpEndpoint != nil {
+			if *cdpEndpoint == "" {
+				parts = append(parts, "cdp_endpoint cleared")
+			} else {
+				parts = append(parts, fmt.Sprintf("cdp_endpoint=%s", *cdpEndpoint))
+			}
+		}
+		if len(parts) == 0 {
+			return mcp.NewToolResultText("No configuration changes requested"), nil
+		}
+		return mcp.NewToolResultText(fmt.Sprintf("Browser configured: %s. Changes take effect on next browser action.", strings.Join(parts, ", "))), nil
+	}
+	return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+}

--- a/tools/configure_test.go
+++ b/tools/configure_test.go
@@ -1,0 +1,179 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aliwatters/rod-mcp/types"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestConfigureToolDefinition(t *testing.T) {
+	if Configure.Name != ConfigureToolKey {
+		t.Errorf("Configure tool name = %q, want %q", Configure.Name, ConfigureToolKey)
+	}
+
+	props := Configure.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Configure tool has no properties")
+	}
+	if _, ok := props["headless"]; !ok {
+		t.Error("Configure tool missing 'headless' property")
+	}
+	if _, ok := props["cdp_endpoint"]; !ok {
+		t.Error("Configure tool missing 'cdp_endpoint' property")
+	}
+
+	// headless and cdp_endpoint should be optional (not required)
+	for _, r := range Configure.InputSchema.Required {
+		if r == "headless" || r == "cdp_endpoint" {
+			t.Errorf("Configure tool parameter %q should not be required", r)
+		}
+	}
+}
+
+func TestConfigureToolRegistered(t *testing.T) {
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == ConfigureToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Configure tool not found in CommonTools")
+	}
+
+	if _, ok := CommonToolHandlers[ConfigureToolKey]; !ok {
+		t.Error("ConfigureHandler not found in CommonToolHandlers")
+	}
+}
+
+func TestConfigureHandlerNoArgs(t *testing.T) {
+	cfg := types.DefaultConfig
+	rodCtx := types.NewContext(context.Background(), cfg)
+	defer rodCtx.Close()
+
+	handler := ConfigureHandler(rodCtx)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if text != "No configuration changes requested" {
+		t.Errorf("unexpected result text: %s", text)
+	}
+}
+
+func TestConfigureHandlerHeadless(t *testing.T) {
+	cfg := types.DefaultConfig
+	cfg.Headless = false
+	rodCtx := types.NewContext(context.Background(), cfg)
+	defer rodCtx.Close()
+
+	handler := ConfigureHandler(rodCtx)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"headless": true,
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if text != "Browser configured: headless=true. Changes take effect on next browser action." {
+		t.Errorf("unexpected result text: %s", text)
+	}
+
+	// Verify config was updated
+	if !rodCtx.Config().Headless {
+		t.Error("expected Headless to be true after reconfigure")
+	}
+}
+
+func TestConfigureHandlerCDPEndpoint(t *testing.T) {
+	cfg := types.DefaultConfig
+	rodCtx := types.NewContext(context.Background(), cfg)
+	defer rodCtx.Close()
+
+	handler := ConfigureHandler(rodCtx)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"cdp_endpoint": "http://127.0.0.1:9222",
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if text != "Browser configured: cdp_endpoint=http://127.0.0.1:9222. Changes take effect on next browser action." {
+		t.Errorf("unexpected result text: %s", text)
+	}
+
+	if rodCtx.Config().CDPEndpoint != "http://127.0.0.1:9222" {
+		t.Errorf("expected CDPEndpoint to be set, got %q", rodCtx.Config().CDPEndpoint)
+	}
+}
+
+func TestConfigureHandlerClearCDPEndpoint(t *testing.T) {
+	cfg := types.DefaultConfig
+	cfg.CDPEndpoint = "http://127.0.0.1:9222"
+	rodCtx := types.NewContext(context.Background(), cfg)
+	defer rodCtx.Close()
+
+	handler := ConfigureHandler(rodCtx)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"cdp_endpoint": "",
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if text != "Browser configured: cdp_endpoint cleared. Changes take effect on next browser action." {
+		t.Errorf("unexpected result text: %s", text)
+	}
+
+	if rodCtx.Config().CDPEndpoint != "" {
+		t.Errorf("expected CDPEndpoint to be cleared, got %q", rodCtx.Config().CDPEndpoint)
+	}
+}
+
+func TestConfigureHandlerBothArgs(t *testing.T) {
+	cfg := types.DefaultConfig
+	rodCtx := types.NewContext(context.Background(), cfg)
+	defer rodCtx.Close()
+
+	handler := ConfigureHandler(rodCtx)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"headless":     true,
+		"cdp_endpoint": "http://127.0.0.1:9222",
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if text == "No configuration changes requested" {
+		t.Error("expected configuration changes to be reported")
+	}
+
+	if !rodCtx.Config().Headless {
+		t.Error("expected Headless to be true")
+	}
+	if rodCtx.Config().CDPEndpoint != "http://127.0.0.1:9222" {
+		t.Error("expected CDPEndpoint to be set")
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -21,6 +21,7 @@ func toolError(action string, err error) error {
 
 var (
 	CommonTools = []mcp.Tool{
+		Configure,
 		Navigation,
 		GoBack,
 		GoForward,
@@ -43,6 +44,7 @@ var (
 		NetworkRequests,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
+		ConfigureToolKey:       ConfigureHandler,
 		NavigationToolKey:      NavigationHandler,
 		GoBackToolKey:          GoBackHandler,
 		GoForwardToolKey:       GoForwardHandler,

--- a/types/context.go
+++ b/types/context.go
@@ -530,6 +530,24 @@ func (ctx *Context) UpdateHeadersForURL(url string) error {
 	return nil
 }
 
+// Reconfigure updates browser settings and closes any running browser so the
+// next tool call reinitializes with the new configuration.  Pass nil for any
+// field to leave it unchanged.
+func (ctx *Context) Reconfigure(headless *bool, cdpEndpoint *string) error {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	if headless != nil {
+		ctx.config.Headless = *headless
+	}
+	if cdpEndpoint != nil {
+		ctx.config.CDPEndpoint = *cdpEndpoint
+	}
+
+	// Close existing browser so the next initial() picks up new config.
+	return ctx.closeBrowser()
+}
+
 // Close the browser
 // PS: This method only used because of server exit
 func (ctx *Context) Close() error {


### PR DESCRIPTION
## Summary

- Add `rod_configure` tool that switches headless/GUI mode and CDP endpoint at runtime, eliminating the need for three separate server entries (`rod-mcp`, `rod-mcp-gui`, `rod-mcp-auth`)
- Add `Reconfigure()` method on `types.Context` that closes any running browser and updates config so the next tool call reinitializes with new settings
- Ship `mcp-registry.json` manifest so router-mcp can reference a single consolidated entry

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (new tests in `tools/configure_test.go`)
- [ ] Manual: start server, call `rod_configure(headless: false)`, then `rod_navigate` — browser appears visible
- [ ] Manual: call `rod_configure(cdp_endpoint: "http://127.0.0.1:9222")` — connects to existing Chrome
- [ ] Manual: call `rod_configure` mid-session — closes browser and reconfigures

Closes #69