### PR TITLE
docs: rewrite README for public discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,16 @@ debug/
 # Build output directory
 build/
 dist/ 
-# Claude Code commands (synced globally via ~/.claude/commands/)
-.claude/commands/
+# Claude Code (synced globally via ~/.claude/)
+.claude/
+
+# Workflow and activity state
+.mcp-activity.json
+.workflow-state.*
+.workflow-reports/
+.ax/
+.claude-profile.json
+
+# Node (used for JS minification only)
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -2,65 +2,212 @@
 
 <div align="center">
 
-<img src="assets/logo2.png" alt="logo" width="400" height="400">
+<img src="assets/logo2.png" alt="Rod MCP" width="300">
 
+**Browser automation for AI agents via the [Model Context Protocol](https://modelcontextprotocol.io/).**
 
-<strong>Wow! It's awesome, now you can use the MCP server of Rod!🚀</strong>
+Built on [Rod](https://github.com/go-rod/rod) — a fast, reliable Go library for controlling Chromium browsers.
 
-<br>
-
-<strong>Rod-MCP provides browser automation capabilities for your applications by using [Rod](https://github.com/go-rod/rod). The server provides many useful mcp tools enable LLMs to interact with the web pages, like click, take screenshot, save page as pdf etc.</strong>
+[![Release](https://img.shields.io/github/v/release/aliwatters/rod-mcp)](https://github.com/aliwatters/rod-mcp/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.23+-00ADD8?logo=go)](https://go.dev)
 
 </div>
 
+---
 
-## Features
+Rod MCP gives AI agents (Claude, Cursor, etc.) full browser control — navigate pages, fill forms, click buttons, take screenshots, generate PDFs, and more. It works in two modes:
 
-- 🚀 Browser automation powered by Rod
-- 🎯 Rich web interaction capabilities
-  - Element clicking
-  - Screenshot capture
-  - PDF generation
-  - And more...
-- 🎨 Headless/GUI mode support
-- ⚡ High performance and stability
-- 🔧 Easy to configure and extend
-- 🤖 Designed for LLMs interaction
+- **Text mode** (default): Uses accessibility snapshots for structured, token-efficient interaction
+- **Vision mode**: Uses screenshots with coordinate-based clicking for visual AI models
 
-## Installation
+## Quick Start
 
-### Prerequisites
+### Install
 
-- Go 1.23 or higher
-- Chrome/Chromium browser
-
-### Steps
-
-1. Clone the repository:
 ```bash
-git clone https://github.com/aliwatters/rod-mcp.git
-cd rod-mcp
+go install github.com/aliwatters/rod-mcp@latest
 ```
 
-2. Install dependencies:
-```bash
-go mod tidy
+Or download a [pre-built binary](https://github.com/aliwatters/rod-mcp/releases) for your platform.
+
+### Configure your MCP client
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "rod-mcp": {
+      "command": "rod-mcp",
+      "args": ["--headless", "--no-banner", "--compact-snapshot"]
+    }
+  }
+}
 ```
 
-3. Build the project:
-```bash
-go build
+**Claude Code** (`~/.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "rod-mcp": {
+      "command": "rod-mcp",
+      "args": ["--headless", "--no-banner", "--compact-snapshot"]
+    }
+  }
+}
 ```
 
-### Docker
+**Cursor** (`.cursor/mcp.json`):
 
-Build and run with Docker:
+```json
+{
+  "mcpServers": {
+    "rod-mcp": {
+      "command": "rod-mcp",
+      "args": ["--headless", "--no-banner", "--compact-snapshot"]
+    }
+  }
+}
+```
+
+That's it. Your AI agent can now browse the web.
+
+## Tools
+
+### Navigation
+
+| Tool | Description |
+|------|-------------|
+| `rod_navigate` | Navigate to a URL |
+| `rod_go_back` | Go back in browser history |
+| `rod_go_forward` | Go forward in browser history |
+| `rod_reload` | Reload the current page |
+
+### Page Interaction (Text Mode)
+
+| Tool | Description |
+|------|-------------|
+| `rod_snapshot` | Capture accessibility snapshot of the page |
+| `rod_click` | Click an element by snapshot reference |
+| `rod_hover` | Hover over an element |
+| `rod_fill` | Type text into an input field |
+| `rod_selector` | Select an option in a dropdown |
+
+### Page Interaction (Vision Mode)
+
+| Tool | Description |
+|------|-------------|
+| `rod_vision_click` | Click at x,y coordinates |
+| `rod_vision_fill` | Click at coordinates and type text |
+
+### Media
+
+| Tool | Description |
+|------|-------------|
+| `rod_screenshot` | Take a PNG screenshot |
+| `rod_pdf` | Generate a PDF of the page |
+
+### Browser Control
+
+| Tool | Description |
+|------|-------------|
+| `rod_evaluate` | Execute JavaScript in the browser |
+| `rod_close_browser` | Close the browser |
+| `rod_set_headers` | Set HTTP headers for requests |
+| `rod_resize` | Set viewport size and device emulation |
+| `rod_handle_dialog` | Handle JavaScript dialogs (alert, confirm, prompt) |
+| `rod_configure` | Change headless mode or CDP endpoint at runtime |
+
+### Tabs
+
+| Tool | Description |
+|------|-------------|
+| `rod_tab_new` | Open a new tab |
+| `rod_tab_list` | List all open tabs |
+| `rod_tab_select` | Switch to a tab |
+| `rod_tab_close` | Close a tab |
+
+### Debugging
+
+| Tool | Description |
+|------|-------------|
+| `rod_wait_for` | Wait for a selector or text to appear |
+| `rod_console_messages` | Capture browser console output |
+| `rod_network_requests` | Capture network requests |
+
+### Input
+
+| Tool | Description |
+|------|-------------|
+| `rod_press` | Press a keyboard key |
+| `rod_file_upload` | Upload files to a file input |
+
+## Configuration
+
+### CLI Flags
+
+```
+--config, -c       Path to config file (default: ./rod-mcp.yaml)
+--headless, -hl    Run browser without GUI
+--vision, -vs      Enable vision mode (coordinate-based tools)
+--compact-snapshot  Reduce snapshot size for fewer tokens
+--output-dir       Directory for screenshots and PDFs
+--omit-images      Don't include base64 images in responses
+--cdp-endpoint     Connect to an existing browser via CDP
+--no-banner        Suppress the startup banner
+```
+
+### Config File
+
+Create a `rod-mcp.yaml` (one is generated automatically on first run):
+
+```yaml
+mode: text                    # text or vision
+headless: false               # run without GUI
+browserBinPath: ""            # path to Chrome/Chromium (auto-detected)
+browserTempDir: ./rod/browser # browser profile directory
+noSandbox: false              # disable Chrome sandbox
+proxy: ""                     # proxy URL (e.g. socks5://localhost:1080)
+compactSnapshot: false        # reduce tokens in snapshots
+outputDir: ""                 # screenshot/PDF output (default: OS temp)
+imageResponses: allow         # allow or omit inline base64 images
+
+# Inject HTTP headers globally
+extraHTTPHeaders:
+  Authorization: "Bearer my-token"
+
+# Inject headers for specific domains (supports wildcards)
+domainHeaders:
+  "*.example.com":
+    X-Custom-Header: "value"
+```
+
+### Connecting to an Existing Browser
+
+To control an already-running Chrome instance (useful for authenticated sessions):
+
+1. Launch Chrome with remote debugging:
+   ```bash
+   google-chrome --remote-debugging-port=9222
+   ```
+
+2. Connect rod-mcp:
+   ```bash
+   rod-mcp --cdp-endpoint http://127.0.0.1:9222
+   ```
+
+   Or use `rod_configure` at runtime to switch to a CDP endpoint.
+
+## Docker
 
 ```bash
 docker build -t rod-mcp .
+docker run -i --rm rod-mcp
 ```
 
-The container runs headless with `--no-sandbox` by default via the baked-in `rod-mcp.yaml`. To supply your own config, mount it as a volume:
+The container runs headless with Chromium. Mount a custom config:
 
 ```bash
 docker run -i --rm -v ./rod-mcp.yaml:/app/rod-mcp.yaml:ro rod-mcp
@@ -72,53 +219,42 @@ Or use Docker Compose:
 docker compose up --build
 ```
 
-## Usage
+## Building from Source
 
-### Basic Usage
-
-1. Clone Repo and Build Self or [Go to Download Release](https://github.com/aliwatters/rod-mcp/releases)
-2. Configure MCP:
-```json
-{
-    "mcpServers": {
-        "rod-mcp": {
-            "command": "rod-mcp",
-            "args": [
-                "-c", "rod-mcp.yaml"
-            ]
-        }
-    }
-}
+```bash
+git clone https://github.com/aliwatters/rod-mcp.git
+cd rod-mcp
+go build -o rod-mcp .
 ```
 
-### Configuration
+### Prerequisites
 
-The configuration file supports the following options:
-- serverName: Server name, default is "Rod Server"
-- browserBinPath: Browser executable file path, use system default browser if empty
-- headless: Whether to run the browser in headless mode, default is false
-- browserTempDir: Browser temporary file directory, default is "./rod/browser"
-- noSandbox: Whether to disable sandbox mode, default is false
-- proxy: Proxy server settings, supports socks5 proxy
+- Go 1.23+
+- Chrome or Chromium
 
 ## Project Structure
 
 ```
 rod-mcp/
-├── assets/          # Static resources
-├── banner/          # Banner resources
-├── cmd.go           # Command line processing
-├── main.go          # Program entry
-├── resources/       # Resource files
-├── server.go        # Server implementation
-├── tools/           # Tool implementation
-├── types/           # Type definitions
-└── utils/           # Utility functions
+├── main.go          # Entry point
+├── cmd.go           # CLI flags and commands
+├── server.go        # MCP server setup and tool registration
+├── runner.go        # Server lifecycle
+├── tools/           # All MCP tool implementations
+│   ├── browser.go   #   evaluate, close, headers, resize, dialog
+│   ├── configure.go #   runtime reconfiguration
+│   ├── debug.go     #   wait_for, console, network
+│   ├── input.go     #   keyboard, file upload
+│   ├── media.go     #   screenshot, PDF
+│   ├── navigation.go#   navigate, back, forward, reload
+│   ├── snapshot.go  #   text mode: snapshot, click, hover, fill, selector
+│   ├── tabs.go      #   tab management
+│   └── vision.go    #   vision mode: coordinate click/fill
+├── types/           # Config, context, snapshot, logging
+├── utils/           # Shared utilities
+├── banner/          # Startup banner
+└── assets/          # Logo images
 ```
-
-## Contribution Guidelines
-
-Welcome to submit Pull Request or create Issue!
 
 ## Attribution
 
@@ -126,4 +262,4 @@ This project is a fork of [go-rod/rod-mcp](https://github.com/go-rod/rod-mcp) by
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
+MIT - see [LICENSE](LICENSE)

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,103 +2,206 @@
 
 <div align="center">
 
-<img src="assets/logo2.png" alt="logo" width="400" height="400">
+<img src="assets/logo2.png" alt="Rod MCP" width="300">
 
+**通过 [Model Context Protocol](https://modelcontextprotocol.io/) 为 AI 代理提供浏览器自动化能力。**
 
-<strong>太棒了! 现在你可以使用 Rod 的 MCP 服务器了!🚀</strong>
+基于 [Rod](https://github.com/go-rod/rod) 构建 — 一个快速、可靠的 Go 语言 Chromium 浏览器控制库。
 
-<br>
-
-<strong>Rod-MCP 通过使用 [Rod](https://github.com/go-rod/rod) 为您的应用程序提供浏览器自动化功能。该服务器提供了许多有用的 MCP 工具，使 LLMs 能够与网页进行交互，比如点击、截图、将页面保存为 PDF 等。</strong>
+[![Release](https://img.shields.io/github/v/release/aliwatters/rod-mcp)](https://github.com/aliwatters/rod-mcp/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.23+-00ADD8?logo=go)](https://go.dev)
 
 </div>
 
-## 功能特性
+---
 
-- 🚀 基于 Rod 的浏览器自动化能力
-- 🎯 支持多种网页交互操作
-  - 点击元素
-  - 截图
-  - 保存页面为 PDF
-  - 更多...
-- 🎨 支持有头/无头模式运行
-- ⚡ 高性能和稳定性
-- 🔧 易于配置和扩展
-- 🤖 专为 LLMs 设计的交互接口
+Rod MCP 让 AI 代理（Claude、Cursor 等）拥有完整的浏览器控制能力 — 页面导航、表单填写、按钮点击、截图、生成 PDF 等。支持两种模式：
 
-## 安装
+- **文本模式**（默认）：使用无障碍快照进行结构化、节省 Token 的交互
+- **视觉模式**：使用截图配合坐标点击，适用于视觉 AI 模型
 
-### 前置要求
+## 快速开始
 
-- Go 1.23 或更高版本
-- Chrome/Chromium 浏览器
+### 安装
 
-### 安装步骤
-
-1. 克隆仓库：
 ```bash
-git clone https://github.com/aliwatters/rod-mcp.git
-cd rod-mcp
+go install github.com/aliwatters/rod-mcp@latest
 ```
 
-2. 安装依赖：
-```bash
-go mod tidy
-```
+或下载适用于你平台的[预编译二进制文件](https://github.com/aliwatters/rod-mcp/releases)。
 
-3. 编译项目：
-```bash
-go build
-```
+### 配置 MCP 客户端
 
-## 使用方法
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`)：
 
-### 基本使用
-
-1. 克隆仓库自行编译 或 [去直接下载二进制文件](https://github.com/aliwatters/rod-mcp/releases)
-2. 配置 MCP：
 ```json
 {
-    "mcpServers": {
-        "rod-mcp": {
-            "command": "rod-mcp",
-            "args": [
-                "-c", "rod-mcp.yaml"
-            ]
-        }
+  "mcpServers": {
+    "rod-mcp": {
+      "command": "rod-mcp",
+      "args": ["--headless", "--no-banner", "--compact-snapshot"]
     }
+  }
 }
 ```
 
-### 配置说明
+配置完成，你的 AI 代理现在可以浏览网页了。
 
-配置文件支持以下选项：
-- serverName: 服务器名称，默认为 "Rod Server"
-- browserBinPath: 浏览器可执行文件路径，留空使用系统默认浏览器
-- headless: 是否使用无头模式运行浏览器，默认为 false
-- browserTempDir: 浏览器临时文件目录，默认为 "./rod/browser"
-- noSandbox: 是否禁用沙箱模式，默认为 false
-- proxy: 代理服务器设置，支持 socks5 代理
+## 工具列表
 
-## 项目结构
+### 导航
+
+| 工具 | 描述 |
+|------|------|
+| `rod_navigate` | 导航到指定 URL |
+| `rod_go_back` | 浏览器后退 |
+| `rod_go_forward` | 浏览器前进 |
+| `rod_reload` | 重新加载页面 |
+
+### 页面交互（文本模式）
+
+| 工具 | 描述 |
+|------|------|
+| `rod_snapshot` | 捕获页面无障碍快照 |
+| `rod_click` | 通过快照引用点击元素 |
+| `rod_hover` | 悬停在元素上 |
+| `rod_fill` | 向输入框输入文本 |
+| `rod_selector` | 在下拉菜单中选择选项 |
+
+### 页面交互（视觉模式）
+
+| 工具 | 描述 |
+|------|------|
+| `rod_vision_click` | 在 x,y 坐标处点击 |
+| `rod_vision_fill` | 在坐标处点击并输入文本 |
+
+### 媒体
+
+| 工具 | 描述 |
+|------|------|
+| `rod_screenshot` | 截取 PNG 格式截图 |
+| `rod_pdf` | 生成页面 PDF |
+
+### 浏览器控制
+
+| 工具 | 描述 |
+|------|------|
+| `rod_evaluate` | 在浏览器中执行 JavaScript |
+| `rod_close_browser` | 关闭浏览器 |
+| `rod_set_headers` | 设置 HTTP 请求头 |
+| `rod_resize` | 设置视口大小和设备模拟 |
+| `rod_handle_dialog` | 处理 JavaScript 对话框 |
+| `rod_configure` | 运行时切换无头模式或 CDP 端点 |
+
+### 标签页
+
+| 工具 | 描述 |
+|------|------|
+| `rod_tab_new` | 打开新标签页 |
+| `rod_tab_list` | 列出所有标签页 |
+| `rod_tab_select` | 切换到指定标签页 |
+| `rod_tab_close` | 关闭标签页 |
+
+### 调试
+
+| 工具 | 描述 |
+|------|------|
+| `rod_wait_for` | 等待选择器或文本出现 |
+| `rod_console_messages` | 捕获浏览器控制台输出 |
+| `rod_network_requests` | 捕获网络请求 |
+
+### 输入
+
+| 工具 | 描述 |
+|------|------|
+| `rod_press` | 按下键盘按键 |
+| `rod_file_upload` | 上传文件 |
+
+## 配置
+
+### 命令行参数
 
 ```
-rod-mcp/
-├── assets/          # 静态资源
-├── banner/          # 横幅资源
-├── cmd.go           # 命令行处理
-├── main.go          # 程序入口
-├── resources/       # 资源文件
-├── server.go        # 服务器实现
-├── tools/           # 工具实现
-├── types/           # 类型定义
-└── utils/           # 工具函数
+--config, -c       配置文件路径（默认：./rod-mcp.yaml）
+--headless, -hl    无界面模式运行浏览器
+--vision, -vs      启用视觉模式（基于坐标的工具）
+--compact-snapshot  压缩快照以减少 Token 使用
+--output-dir       截图和 PDF 输出目录
+--omit-images      不在响应中包含 base64 图片
+--cdp-endpoint     通过 CDP 连接已有浏览器
+--no-banner        不显示启动横幅
 ```
 
-## 贡献指南
+### 配置文件
 
-欢迎提交 Pull Request 或创建 Issue！
+创建 `rod-mcp.yaml`（首次运行时自动生成）：
+
+```yaml
+mode: text                    # text 或 vision
+headless: false               # 无界面模式
+browserBinPath: ""            # Chrome/Chromium 路径（自动检测）
+browserTempDir: ./rod/browser # 浏览器配置目录
+noSandbox: false              # 禁用 Chrome 沙箱
+proxy: ""                     # 代理 URL（例如 socks5://localhost:1080）
+compactSnapshot: false        # 压缩快照以减少 Token
+outputDir: ""                 # 截图/PDF 输出目录（默认：系统临时目录）
+imageResponses: allow         # allow 或 omit 内联 base64 图片
+
+# 全局注入 HTTP 请求头
+extraHTTPHeaders:
+  Authorization: "Bearer my-token"
+
+# 为特定域名注入请求头（支持通配符）
+domainHeaders:
+  "*.example.com":
+    X-Custom-Header: "value"
+```
+
+### 连接已有浏览器
+
+控制已运行的 Chrome 实例（适用于已认证的会话）：
+
+1. 启动 Chrome 并开启远程调试：
+   ```bash
+   google-chrome --remote-debugging-port=9222
+   ```
+
+2. 连接 rod-mcp：
+   ```bash
+   rod-mcp --cdp-endpoint http://127.0.0.1:9222
+   ```
+
+## Docker
+
+```bash
+docker build -t rod-mcp .
+docker run -i --rm rod-mcp
+```
+
+容器默认以无头模式运行 Chromium。挂载自定义配置：
+
+```bash
+docker run -i --rm -v ./rod-mcp.yaml:/app/rod-mcp.yaml:ro rod-mcp
+```
+
+## 从源码构建
+
+```bash
+git clone https://github.com/aliwatters/rod-mcp.git
+cd rod-mcp
+go build -o rod-mcp .
+```
+
+### 前置要求
+
+- Go 1.23+
+- Chrome 或 Chromium
+
+## 归属
+
+本项目是 Go Rod Team 的 [go-rod/rod-mcp](https://github.com/go-rod/rod-mcp) 的分支。原项目为通过 Model Context Protocol 实现浏览器自动化奠定了基础。
 
 ## 许可证
 
-本项目采用 MIT 许可证 - 详见 [LICENSE](LICENSE) 文件
+MIT - 详见 [LICENSE](LICENSE)


### PR DESCRIPTION
## Summary

- Rewrote English and Chinese READMEs for public discovery: clear description, badges, `go install` quick-start, MCP client configs (Claude Desktop, Claude Code, Cursor), complete tool reference (28 tools), full configuration docs, Docker usage
- Updated `.gitignore` to exclude development artifacts (`.claude/`, `.ax/`, `.mcp-activity.json`, `.workflow-state.*`, `node_modules/`, etc.)

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify badges resolve (release, license, Go version)
- [ ] Confirm `go install github.com/aliwatters/rod-mcp@latest` works
- [ ] Confirm `go build` and `go test ./...` still pass