### PR TITLE
chore: add auto-update-branches workflow to keep PRs current

### DIFF
--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -1,0 +1,26 @@
+name: Auto-Update PR Branches
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: auto-update-branches
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: write
+
+jobs:
+  update-branches:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: aliwatters/auto-update-branches@v1
+        with:
+          update-mode: "next"
+          cancel-stale-ci: "true"
+          conflict-label: "needs-rebase"


### PR DESCRIPTION
## Summary
- Adds auto-update-branches workflow that runs on push to main
- Automatically updates open PR branches to prevent auto-merge stalls with strict branch protection
- Cancels stale CI runs and labels conflicting PRs with needs-rebase

Closes #82