### PR TITLE
fix(evaluate): return actual JS result instead of nil

### DIFF
--- a/tools/browser.go
+++ b/tools/browser.go
@@ -61,6 +61,8 @@ var (
 				Expression:            script,
 				ObjectGroup:           "console",
 				IncludeCommandLineAPI: true,
+				ReturnByValue:         true,
+				AwaitPromise:          true,
 			}.Call(page)
 			if err != nil {
 				return toolErr("evaluate code", err)


### PR DESCRIPTION
## Summary

- Fixes `rod_evaluate` always returning `<nil>` for all JavaScript expressions
- Added `ReturnByValue: true` to the `RuntimeEvaluate` CDP call so Chrome serializes the result as a JSON value instead of returning an object reference
- Added `AwaitPromise: true` so promise-returning expressions are properly awaited

Fixes #84

## Test plan

- [ ] Run `rod_evaluate` with `script: "1 + 1"` and verify it returns `2` instead of `<nil>`
- [ ] Run `rod_evaluate` with `script: "document.title"` and verify it returns the page title
- [ ] Run `rod_evaluate` with a promise-returning expression and verify it awaits and returns the resolved value

🤖 Generated with [Claude Code](https://claude.com/claude-code)