### PR TITLE
fix: wrap function expressions in rod_evaluate

### DIFF
--- a/tools/browser.go
+++ b/tools/browser.go
@@ -57,8 +57,14 @@ var (
 			if err != nil {
 				return toolErr("evaluate", err)
 			}
+			// Wrap function expressions so they get invoked, not just defined.
+			// e.g. "() => document.title" becomes "(() => document.title)()"
+			expression := script
+			if len(script) > 0 && (script[0] == '(' || len(script) > 8 && script[:8] == "function") {
+				expression = "(" + script + ")()"
+			}
 			r, err := proto.RuntimeEvaluate{
-				Expression:            script,
+				Expression:            expression,
 				ObjectGroup:           "console",
 				IncludeCommandLineAPI: true,
 				ReturnByValue:         true,


### PR DESCRIPTION
## Summary
- When function expressions (e.g. `() => document.title`) are passed to `rod_evaluate`, CDP evaluates the definition but never invokes it, returning an empty object
- Wrap expressions starting with `(` or `function` in `(...)()` to auto-invoke them
- Raw expressions like `document.title` continue to work as before

Closes #84

## Test plan
- [x] `() => document.title` returns page title
- [x] `() => 42` returns `42`
- [x] `document.title` (raw expression) still works
- [x] `function() { return 1 }` style also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)