### PR TITLE
feat: add rod_cookies, rod_storage, and rod_permissions tools

### DIFF
--- a/tools/cookies.go
+++ b/tools/cookies.go
@@ -1,0 +1,162 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	CookiesToolKey = "rod_cookies"
+)
+
+var (
+	Cookies = mcp.NewTool(CookiesToolKey,
+		mcp.WithDescription("Manage browser cookies via CDP. Get, set, delete, or clear cookies including httpOnly cookies not visible to document.cookie."),
+		mcp.WithString("action", mcp.Description("Action to perform"), mcp.Required(), mcp.Enum("get", "set", "delete", "clear")),
+		mcp.WithString("url", mcp.Description("URL to get cookies for (get) or associate with (set/delete). Defaults to current page URL.")),
+		mcp.WithString("name", mcp.Description("Cookie name (required for set and delete)")),
+		mcp.WithString("value", mcp.Description("Cookie value (required for set)")),
+		mcp.WithString("domain", mcp.Description("Cookie domain (optional for set/delete)")),
+		mcp.WithString("path", mcp.Description("Cookie path (optional for set/delete)")),
+		mcp.WithBoolean("secure", mcp.Description("Secure flag (optional for set)")),
+		mcp.WithBoolean("httpOnly", mcp.Description("HttpOnly flag (optional for set)")),
+		mcp.WithString("sameSite", mcp.Description("SameSite attribute (optional for set)"), mcp.Enum("Strict", "Lax", "None")),
+	)
+)
+
+var (
+	CookiesHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("cookies", err)
+			}
+
+			action, err := getStringArg(request.GetArguments(), "action")
+			if err != nil {
+				return toolErr("cookies", err)
+			}
+			args := request.GetArguments()
+
+			switch action {
+			case "get":
+				var urls []string
+				if u := getOptionalStringArg(args, "url"); u != "" {
+					urls = []string{u}
+				}
+				resp, err := proto.NetworkGetCookies{Urls: urls}.Call(page)
+				if err != nil {
+					return toolErr("get cookies", err)
+				}
+				if len(resp.Cookies) == 0 {
+					return mcp.NewToolResultText("No cookies found"), nil
+				}
+
+				type cookieInfo struct {
+					Name     string `json:"name"`
+					Value    string `json:"value"`
+					Domain   string `json:"domain"`
+					Path     string `json:"path"`
+					Secure   bool   `json:"secure,omitempty"`
+					HTTPOnly bool   `json:"httpOnly,omitempty"`
+					SameSite string `json:"sameSite,omitempty"`
+					Session  bool   `json:"session,omitempty"`
+				}
+				cookies := make([]cookieInfo, 0, len(resp.Cookies))
+				for _, c := range resp.Cookies {
+					cookies = append(cookies, cookieInfo{
+						Name:     c.Name,
+						Value:    c.Value,
+						Domain:   c.Domain,
+						Path:     c.Path,
+						Secure:   c.Secure,
+						HTTPOnly: c.HTTPOnly,
+						SameSite: string(c.SameSite),
+						Session:  c.Session,
+					})
+				}
+				out, err := json.MarshalIndent(cookies, "", "  ")
+				if err != nil {
+					return toolErr("format cookies", err)
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("%d cookies:\n%s", len(cookies), string(out))), nil
+
+			case "set":
+				name, err := getStringArg(args, "name")
+				if err != nil {
+					return toolErr("set cookie", err)
+				}
+				value, err := getStringArg(args, "value")
+				if err != nil {
+					return toolErr("set cookie", err)
+				}
+				cookie := proto.NetworkSetCookie{
+					Name:     name,
+					Value:    value,
+					URL:      getOptionalStringArg(args, "url"),
+					Domain:   getOptionalStringArg(args, "domain"),
+					Path:     getOptionalStringArg(args, "path"),
+					Secure:   getOptionalBoolArg(args, "secure", false),
+					HTTPOnly: getOptionalBoolArg(args, "httpOnly", false),
+				}
+				// Default to current page URL if neither url nor domain is specified
+				if cookie.URL == "" && cookie.Domain == "" {
+					info, err := page.Info()
+					if err == nil {
+						cookie.URL = info.URL
+					}
+				}
+				if ss := getOptionalStringArg(args, "sameSite"); ss != "" {
+					cookie.SameSite = proto.NetworkCookieSameSite(ss)
+				}
+				_, err = cookie.Call(page)
+				if err != nil {
+					return toolErr(fmt.Sprintf("set cookie %q", name), err)
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("Cookie %q set successfully", name)), nil
+
+			case "delete":
+				name, err := getStringArg(args, "name")
+				if err != nil {
+					return toolErr("delete cookie", err)
+				}
+				delReq := proto.NetworkDeleteCookies{
+					Name:   name,
+					URL:    getOptionalStringArg(args, "url"),
+					Domain: getOptionalStringArg(args, "domain"),
+					Path:   getOptionalStringArg(args, "path"),
+				}
+				// Default to current page URL if no scope is specified
+				if delReq.URL == "" && delReq.Domain == "" {
+					info, err := page.Info()
+					if err == nil {
+						delReq.URL = info.URL
+					}
+				}
+				err = delReq.Call(page)
+				if err != nil {
+					return toolErr(fmt.Sprintf("delete cookie %q", name), err)
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("Cookie %q deleted successfully", name)), nil
+
+			case "clear":
+				err := proto.NetworkClearBrowserCookies{}.Call(page)
+				if err != nil {
+					return toolErr("clear cookies", err)
+				}
+				return mcp.NewToolResultText("All cookies cleared"), nil
+
+			default:
+				return nil, fmt.Errorf("invalid action %q: must be get, set, delete, or clear", action)
+			}
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)

--- a/tools/cookies_test.go
+++ b/tools/cookies_test.go
@@ -1,0 +1,49 @@
+package tools
+
+import "testing"
+
+func TestCookiesToolDefinition(t *testing.T) {
+	if Cookies.Name != CookiesToolKey {
+		t.Errorf("Cookies tool name = %q, want %q", Cookies.Name, CookiesToolKey)
+	}
+
+	props := Cookies.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Cookies tool has no properties")
+	}
+
+	for _, param := range []string{"action", "url", "name", "value", "domain", "path", "secure", "httpOnly", "sameSite"} {
+		if _, ok := props[param]; !ok {
+			t.Errorf("Cookies tool missing %q property", param)
+		}
+	}
+
+	// "action" should be required
+	found := false
+	for _, r := range Cookies.InputSchema.Required {
+		if r == "action" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Cookies tool 'action' parameter should be required")
+	}
+}
+
+func TestCookiesToolRegistered(t *testing.T) {
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == CookiesToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Cookies tool not found in CommonTools")
+	}
+
+	if _, ok := CommonToolHandlers[CookiesToolKey]; !ok {
+		t.Error("CookiesHandler not found in CommonToolHandlers")
+	}
+}

--- a/tools/permissions.go
+++ b/tools/permissions.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+	"github.com/aliwatters/rod-mcp/utils"
+)
+
+const (
+	PermissionsToolKey = "rod_permissions"
+)
+
+var (
+	Permissions = mcp.NewTool(PermissionsToolKey,
+		mcp.WithDescription("Grant or reset browser permissions (geolocation, notifications, camera, microphone, clipboard, etc.)"),
+		mcp.WithString("action", mcp.Description("Action to perform"), mcp.Required(), mcp.Enum("grant", "reset")),
+		mcp.WithArray("permissions", mcp.Description("Permissions to grant: geolocation, notifications, audioCapture, videoCapture, clipboardReadWrite, midi, sensors, idleDetection, backgroundSync, etc."),
+			mcp.Items(map[string]interface{}{"type": "string"})),
+		mcp.WithString("origin", mcp.Description("Origin to apply permissions to (e.g. https://example.com). Applies to all origins if not specified.")),
+	)
+)
+
+var (
+	PermissionsHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			browser, err := rodCtx.ControlledBrowser()
+			if err != nil {
+				return toolErr("permissions", err)
+			}
+
+			action, err := getStringArg(request.GetArguments(), "action")
+			if err != nil {
+				return toolErr("permissions", err)
+			}
+			origin := getOptionalStringArg(request.GetArguments(), "origin")
+
+			switch action {
+			case "grant":
+				perms, err := utils.OptionalStringArrayParam(request, "permissions")
+				if err != nil {
+					return toolErr("permissions grant", err)
+				}
+				if len(perms) == 0 {
+					return nil, fmt.Errorf("permissions array is required for grant action")
+				}
+				permTypes := make([]proto.BrowserPermissionType, len(perms))
+				for i, p := range perms {
+					permTypes[i] = proto.BrowserPermissionType(p)
+				}
+				err = proto.BrowserGrantPermissions{
+					Permissions: permTypes,
+					Origin:      origin,
+				}.Call(browser)
+				if err != nil {
+					return toolErr("grant permissions", err)
+				}
+				scope := "all origins"
+				if origin != "" {
+					scope = origin
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("Granted permissions [%s] for %s", strings.Join(perms, ", "), scope)), nil
+
+			case "reset":
+				err := proto.BrowserResetPermissions{}.Call(browser)
+				if err != nil {
+					return toolErr("reset permissions", err)
+				}
+				return mcp.NewToolResultText("All permissions reset to defaults"), nil
+
+			default:
+				return nil, fmt.Errorf("invalid action %q: must be grant or reset", action)
+			}
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)

--- a/tools/permissions_test.go
+++ b/tools/permissions_test.go
@@ -1,0 +1,49 @@
+package tools
+
+import "testing"
+
+func TestPermissionsToolDefinition(t *testing.T) {
+	if Permissions.Name != PermissionsToolKey {
+		t.Errorf("Permissions tool name = %q, want %q", Permissions.Name, PermissionsToolKey)
+	}
+
+	props := Permissions.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Permissions tool has no properties")
+	}
+
+	for _, param := range []string{"action", "permissions", "origin"} {
+		if _, ok := props[param]; !ok {
+			t.Errorf("Permissions tool missing %q property", param)
+		}
+	}
+
+	// "action" should be required
+	found := false
+	for _, r := range Permissions.InputSchema.Required {
+		if r == "action" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Permissions tool 'action' parameter should be required")
+	}
+}
+
+func TestPermissionsToolRegistered(t *testing.T) {
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == PermissionsToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Permissions tool not found in CommonTools")
+	}
+
+	if _, ok := CommonToolHandlers[PermissionsToolKey]; !ok {
+		t.Error("PermissionsHandler not found in CommonToolHandlers")
+	}
+}

--- a/tools/storage.go
+++ b/tools/storage.go
@@ -1,0 +1,128 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	StorageToolKey = "rod_storage"
+)
+
+var (
+	Storage = mcp.NewTool(StorageToolKey,
+		mcp.WithDescription("Read and write browser localStorage or sessionStorage"),
+		mcp.WithString("type", mcp.Description("Storage type"), mcp.Required(), mcp.Enum("local", "session")),
+		mcp.WithString("action", mcp.Description("Action to perform"), mcp.Required(), mcp.Enum("get", "set", "remove", "list", "clear")),
+		mcp.WithString("key", mcp.Description("Storage key (required for get, set, remove)")),
+		mcp.WithString("value", mcp.Description("Value to set (required for set)")),
+	)
+)
+
+var (
+	StorageHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("storage", err)
+			}
+
+			args := request.GetArguments()
+			storageType, err := getStringArg(args, "type")
+			if err != nil {
+				return toolErr("storage", err)
+			}
+			action, err := getStringArg(args, "action")
+			if err != nil {
+				return toolErr("storage", err)
+			}
+
+			var storageObj string
+			switch storageType {
+			case "local":
+				storageObj = "localStorage"
+			case "session":
+				storageObj = "sessionStorage"
+			default:
+				return nil, fmt.Errorf("invalid type %q: must be local or session", storageType)
+			}
+
+			switch action {
+			case "get":
+				key, err := getStringArg(args, "key")
+				if err != nil {
+					return toolErr("storage get", err)
+				}
+				r, err := page.Eval(fmt.Sprintf(`(key) => %s.getItem(key)`, storageObj), key)
+				if err != nil {
+					return toolErr("storage get", err)
+				}
+				if r.Value.Nil() {
+					return mcp.NewToolResultText(fmt.Sprintf("Key %q not found in %s", key, storageObj)), nil
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("%s[%q] = %s", storageObj, key, r.Value.Str())), nil
+
+			case "set":
+				key, err := getStringArg(args, "key")
+				if err != nil {
+					return toolErr("storage set", err)
+				}
+				value, err := getStringArg(args, "value")
+				if err != nil {
+					return toolErr("storage set", err)
+				}
+				_, err = page.Eval(fmt.Sprintf(`(key, value) => %s.setItem(key, value)`, storageObj), key, value)
+				if err != nil {
+					return toolErr("storage set", err)
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("Set %s[%q] successfully", storageObj, key)), nil
+
+			case "remove":
+				key, err := getStringArg(args, "key")
+				if err != nil {
+					return toolErr("storage remove", err)
+				}
+				_, err = page.Eval(fmt.Sprintf(`(key) => %s.removeItem(key)`, storageObj), key)
+				if err != nil {
+					return toolErr("storage remove", err)
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("Removed %s[%q] successfully", storageObj, key)), nil
+
+			case "list":
+				r, err := page.Eval(fmt.Sprintf(`() => {
+					const s = %s;
+					const items = {};
+					for (let i = 0; i < s.length; i++) {
+						const key = s.key(i);
+						items[key] = s.getItem(key);
+					}
+					return JSON.stringify(items, null, 2);
+				}`, storageObj))
+				if err != nil {
+					return toolErr("storage list", err)
+				}
+				val := r.Value.Str()
+				if val == "{}" {
+					return mcp.NewToolResultText(fmt.Sprintf("%s is empty", storageObj)), nil
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("%s contents:\n%s", storageObj, val)), nil
+
+			case "clear":
+				_, err := page.Eval(fmt.Sprintf(`() => %s.clear()`, storageObj))
+				if err != nil {
+					return toolErr("storage clear", err)
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("%s cleared successfully", storageObj)), nil
+
+			default:
+				return nil, fmt.Errorf("invalid action %q: must be get, set, remove, list, or clear", action)
+			}
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)

--- a/tools/storage_test.go
+++ b/tools/storage_test.go
@@ -1,0 +1,50 @@
+package tools
+
+import "testing"
+
+func TestStorageToolDefinition(t *testing.T) {
+	if Storage.Name != StorageToolKey {
+		t.Errorf("Storage tool name = %q, want %q", Storage.Name, StorageToolKey)
+	}
+
+	props := Storage.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Storage tool has no properties")
+	}
+
+	for _, param := range []string{"type", "action", "key", "value"} {
+		if _, ok := props[param]; !ok {
+			t.Errorf("Storage tool missing %q property", param)
+		}
+	}
+
+	// "type" and "action" should be required
+	requiredFound := map[string]bool{"type": false, "action": false}
+	for _, r := range Storage.InputSchema.Required {
+		if _, ok := requiredFound[r]; ok {
+			requiredFound[r] = true
+		}
+	}
+	for param, found := range requiredFound {
+		if !found {
+			t.Errorf("Storage tool %q parameter should be required", param)
+		}
+	}
+}
+
+func TestStorageToolRegistered(t *testing.T) {
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == StorageToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Storage tool not found in CommonTools")
+	}
+
+	if _, ok := CommonToolHandlers[StorageToolKey]; !ok {
+		t.Error("StorageHandler not found in CommonToolHandlers")
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -45,6 +45,9 @@ var (
 		Scroll,
 		HTML,
 		Coverage,
+		Cookies,
+		Storage,
+		Permissions,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		ConfigureToolKey:       ConfigureHandler,
@@ -71,6 +74,9 @@ var (
 		ScrollToolKey:          ScrollHandler,
 		HTMLToolKey:            HTMLHandler,
 		CoverageToolKey:        CoverageHandler,
+		CookiesToolKey:         CookiesHandler,
+		StorageToolKey:         StorageHandler,
+		PermissionsToolKey:     PermissionsHandler,
 	}
 )
 

--- a/types/context.go
+++ b/types/context.go
@@ -225,6 +225,16 @@ func (ctx *Context) ControlledPage() (*rod.Page, error) {
 	return ctx.page, nil
 }
 
+// ControlledBrowser returns the browser instance, or an error if no browser is running.
+func (ctx *Context) ControlledBrowser() (*rod.Browser, error) {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+	if ctx.browser == nil {
+		return nil, errors.New("no browser running, call rod_navigate first")
+	}
+	return ctx.browser, nil
+}
+
 func (ctx *Context) initial() error {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()


### PR DESCRIPTION
## Summary

- **rod_cookies** (#97): Full cookie management via CDP — get (including httpOnly), set, delete, and clear. Defaults to current page URL when no url/domain specified.
- **rod_storage** (#98): Read/write localStorage and sessionStorage — get, set, remove, list, clear. Uses parameterized `page.Eval` (no JS injection risk).
- **rod_permissions** (#107): Grant/reset browser permissions (geolocation, camera, notifications, clipboard, etc.) via CDP Browser domain.

Adds `Context.ControlledBrowser()` for browser-level CDP commands needed by the permissions tool.

## Review findings addressed

- Cookies set/delete default to current page URL when neither url nor domain is specified
- Storage get reorders nil check before value extraction for clarity
- All tools use `mcp.Enum()` constraints on action parameters

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (tool definition + registration tests)
- [ ] Manual: `rod_cookies` get/set/delete/clear lifecycle
- [ ] Manual: `rod_storage` get/set/remove/list/clear for both local and session
- [ ] Manual: `rod_permissions` grant geolocation + reset

Closes #97, closes #98, closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)