### PR TITLE
feat: add rod_intercept, rod_response_body, and rod_websocket tools

### DIFF
--- a/tools/intercept.go
+++ b/tools/intercept.go
@@ -1,0 +1,255 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	InterceptToolKey = "rod_intercept"
+)
+
+var (
+	Intercept = mcp.NewTool(InterceptToolKey,
+		mcp.WithDescription("Intercept network requests to mock responses, block requests, or simulate errors. Enable interception first, then add rules. Each intercepted request is matched against rules in order."),
+		mcp.WithString("action", mcp.Description("Action to perform"), mcp.Required(), mcp.Enum("enable", "mock", "block", "fail", "disable", "list")),
+		mcp.WithString("urlPattern", mcp.Description("URL pattern to match (wildcards: * = zero or more, ? = exactly one). Required for mock, block, fail.")),
+		mcp.WithNumber("status", mcp.Description("HTTP status code for mock response (default: 200)")),
+		mcp.WithObject("headers", mcp.Description("Response headers for mock response as key-value pairs")),
+		mcp.WithString("body", mcp.Description("Response body for mock response")),
+		mcp.WithString("errorReason", mcp.Description("Error reason for fail action"), mcp.Enum("Failed", "Aborted", "TimedOut", "AccessDenied", "ConnectionClosed", "ConnectionReset", "ConnectionRefused", "ConnectionAborted", "ConnectionFailed", "NameNotResolved", "InternetDisconnected", "AddressUnreachable", "BlockedByClient", "BlockedByResponse")),
+	)
+)
+
+var (
+	InterceptHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("intercept", err)
+			}
+
+			action, err := getStringArg(request.GetArguments(), "action")
+			if err != nil {
+				return toolErr("intercept", err)
+			}
+			args := request.GetArguments()
+
+			switch action {
+			case "enable":
+				err := proto.FetchEnable{
+					Patterns: []*proto.FetchRequestPattern{
+						{URLPattern: "*"},
+					},
+				}.Call(page)
+				if err != nil {
+					return toolErr("enable request interception", err)
+				}
+
+				rodCtx.SetInterceptEnabled(true)
+
+				// Start event listener for paused requests
+				go page.EachEvent(func(e *proto.FetchRequestPaused) {
+					rules := rodCtx.InterceptRules()
+
+					for _, rule := range rules {
+						if matchURLPattern(e.Request.URL, rule.URLPattern) {
+							switch rule.Action {
+							case "mock":
+								if err := (proto.FetchFulfillRequest{
+									RequestID:       e.RequestID,
+									ResponseCode:    rule.Status,
+									ResponseHeaders: rule.Headers,
+									Body:            rule.Body,
+								}).Call(page); err != nil {
+									log.Debugf("fulfill request %s: %s", e.RequestID, err)
+								}
+								return
+							case "block", "fail":
+								reason := rule.ErrorReason
+								if reason == "" {
+									reason = proto.NetworkErrorReasonBlockedByClient
+								}
+								if err := (proto.FetchFailRequest{
+									RequestID:   e.RequestID,
+									ErrorReason: reason,
+								}).Call(page); err != nil {
+									log.Debugf("fail request %s: %s", e.RequestID, err)
+								}
+								return
+							}
+						}
+					}
+					// No matching rule — continue the request
+					if err := (proto.FetchContinueRequest{
+						RequestID: e.RequestID,
+					}).Call(page); err != nil {
+						log.Debugf("continue request %s: %s", e.RequestID, err)
+					}
+				})()
+
+				return mcp.NewToolResultText("Request interception enabled"), nil
+
+			case "mock":
+				if !rodCtx.InterceptEnabled() {
+					return toolErr("intercept mock", fmt.Errorf("interception not enabled, call with action=enable first"))
+				}
+				urlPattern, err := getStringArg(args, "urlPattern")
+				if err != nil {
+					return toolErr("intercept mock", err)
+				}
+				status := int(getOptionalFloatArg(args, "status", 200))
+				body := getOptionalStringArg(args, "body")
+
+				var headers []*proto.FetchHeaderEntry
+				if h, ok := args["headers"].(map[string]interface{}); ok {
+					for k, v := range h {
+						headers = append(headers, &proto.FetchHeaderEntry{
+							Name:  k,
+							Value: fmt.Sprintf("%v", v),
+						})
+					}
+				}
+				if len(headers) == 0 {
+					headers = []*proto.FetchHeaderEntry{
+						{Name: "Content-Type", Value: "application/json"},
+					}
+				}
+
+				rodCtx.AddInterceptRule(types.InterceptRule{
+					URLPattern: urlPattern,
+					Action:     "mock",
+					Status:     status,
+					Headers:    headers,
+					Body:       []byte(body),
+				})
+
+				return mcp.NewToolResultText(fmt.Sprintf("Mock rule added: %s → %d", urlPattern, status)), nil
+
+			case "block":
+				if !rodCtx.InterceptEnabled() {
+					return toolErr("intercept block", fmt.Errorf("interception not enabled, call with action=enable first"))
+				}
+				urlPattern, err := getStringArg(args, "urlPattern")
+				if err != nil {
+					return toolErr("intercept block", err)
+				}
+
+				rodCtx.AddInterceptRule(types.InterceptRule{
+					URLPattern:  urlPattern,
+					Action:      "block",
+					ErrorReason: proto.NetworkErrorReasonBlockedByClient,
+				})
+
+				return mcp.NewToolResultText(fmt.Sprintf("Block rule added: %s", urlPattern)), nil
+
+			case "fail":
+				if !rodCtx.InterceptEnabled() {
+					return toolErr("intercept fail", fmt.Errorf("interception not enabled, call with action=enable first"))
+				}
+				urlPattern, err := getStringArg(args, "urlPattern")
+				if err != nil {
+					return toolErr("intercept fail", err)
+				}
+				reason := getOptionalStringArg(args, "errorReason")
+				if reason == "" {
+					reason = "Failed"
+				}
+
+				rodCtx.AddInterceptRule(types.InterceptRule{
+					URLPattern:  urlPattern,
+					Action:      "fail",
+					ErrorReason: proto.NetworkErrorReason(reason),
+				})
+
+				return mcp.NewToolResultText(fmt.Sprintf("Fail rule added: %s → %s", urlPattern, reason)), nil
+
+			case "list":
+				rules := rodCtx.InterceptRules()
+				enabled := rodCtx.InterceptEnabled()
+
+				if !enabled {
+					return mcp.NewToolResultText("Interception is not enabled"), nil
+				}
+				if len(rules) == 0 {
+					return mcp.NewToolResultText("Interception enabled, no rules configured"), nil
+				}
+
+				var result strings.Builder
+				result.WriteString(fmt.Sprintf("Interception rules (%d):\n", len(rules)))
+				for i, r := range rules {
+					switch r.Action {
+					case "mock":
+						result.WriteString(fmt.Sprintf("  %d. MOCK %s → %d\n", i+1, r.URLPattern, r.Status))
+					case "block":
+						result.WriteString(fmt.Sprintf("  %d. BLOCK %s\n", i+1, r.URLPattern))
+					case "fail":
+						result.WriteString(fmt.Sprintf("  %d. FAIL %s → %s\n", i+1, r.URLPattern, r.ErrorReason))
+					}
+				}
+				return mcp.NewToolResultText(result.String()), nil
+
+			case "disable":
+				err := proto.FetchDisable{}.Call(page)
+				if err != nil {
+					return toolErr("disable request interception", err)
+				}
+				rodCtx.SetInterceptEnabled(false)
+
+				return mcp.NewToolResultText("Request interception disabled and rules cleared"), nil
+
+			default:
+				return nil, fmt.Errorf("invalid action %q: must be enable, mock, block, fail, list, or disable", action)
+			}
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)
+
+// matchURLPattern matches a URL against a simple wildcard pattern.
+// * matches zero or more characters, ? matches exactly one character.
+func matchURLPattern(url, pattern string) bool {
+	return matchWildcard(url, pattern)
+}
+
+func matchWildcard(s, pattern string) bool {
+	for len(pattern) > 0 {
+		switch pattern[0] {
+		case '*':
+			// Skip consecutive *
+			for len(pattern) > 0 && pattern[0] == '*' {
+				pattern = pattern[1:]
+			}
+			if len(pattern) == 0 {
+				return true
+			}
+			for i := 0; i <= len(s); i++ {
+				if matchWildcard(s[i:], pattern) {
+					return true
+				}
+			}
+			return false
+		case '?':
+			if len(s) == 0 {
+				return false
+			}
+			s = s[1:]
+			pattern = pattern[1:]
+		default:
+			if len(s) == 0 || s[0] != pattern[0] {
+				return false
+			}
+			s = s[1:]
+			pattern = pattern[1:]
+		}
+	}
+	return len(s) == 0
+}

--- a/tools/intercept_test.go
+++ b/tools/intercept_test.go
@@ -1,0 +1,74 @@
+package tools
+
+import "testing"
+
+func TestInterceptToolDefinition(t *testing.T) {
+	if Intercept.Name != InterceptToolKey {
+		t.Errorf("Intercept tool name = %q, want %q", Intercept.Name, InterceptToolKey)
+	}
+
+	props := Intercept.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Intercept tool has no properties")
+	}
+
+	for _, param := range []string{"action", "urlPattern", "status", "headers", "body", "errorReason"} {
+		if _, ok := props[param]; !ok {
+			t.Errorf("Intercept tool missing %q property", param)
+		}
+	}
+
+	// "action" should be required
+	found := false
+	for _, r := range Intercept.InputSchema.Required {
+		if r == "action" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Intercept tool 'action' parameter should be required")
+	}
+}
+
+func TestInterceptToolRegistered(t *testing.T) {
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == InterceptToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Intercept tool not found in CommonTools")
+	}
+
+	if _, ok := CommonToolHandlers[InterceptToolKey]; !ok {
+		t.Error("InterceptHandler not found in CommonToolHandlers")
+	}
+}
+
+func TestMatchWildcard(t *testing.T) {
+	tests := []struct {
+		url, pattern string
+		want         bool
+	}{
+		{"https://api.example.com/data", "*api.example.com*", true},
+		{"https://api.example.com/data", "*other.com*", false},
+		{"https://example.com/path", "*", true},
+		{"https://example.com/path", "https://example.com/path", true},
+		{"https://example.com/path", "https://example.com/other", false},
+		{"https://example.com/a", "https://example.com/?", true},
+		{"https://example.com/ab", "https://example.com/?", false},
+		{"", "*", true},
+		{"", "", true},
+		{"a", "", false},
+	}
+
+	for _, tc := range tests {
+		got := matchWildcard(tc.url, tc.pattern)
+		if got != tc.want {
+			t.Errorf("matchWildcard(%q, %q) = %v, want %v", tc.url, tc.pattern, got, tc.want)
+		}
+	}
+}

--- a/tools/response_body.go
+++ b/tools/response_body.go
@@ -1,0 +1,81 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	ResponseBodyToolKey = "rod_response_body"
+)
+
+var (
+	ResponseBody = mcp.NewTool(ResponseBodyToolKey,
+		mcp.WithDescription("Get the response body of a captured network request. Use rod_network_requests first to see available requests and their indices."),
+		mcp.WithNumber("index", mcp.Description("Index of the request from rod_network_requests output (0-based)"), mcp.Required()),
+		mcp.WithNumber("maxLength", mcp.Description("Maximum response body length to return in characters (default: 100000)")),
+	)
+)
+
+var (
+	ResponseBodyHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("response body", err)
+			}
+
+			args := request.GetArguments()
+			index, err := getFloatArg(args, "index")
+			if err != nil {
+				return toolErr("response body", err)
+			}
+			maxLength := int(getOptionalFloatArg(args, "maxLength", 100000))
+
+			requestID, err := rodCtx.GetRequestID(int(index))
+			if err != nil {
+				return toolErr("response body", err)
+			}
+
+			result, err := proto.NetworkGetResponseBody{
+				RequestID: proto.NetworkRequestID(requestID),
+			}.Call(page)
+			if err != nil {
+				return toolErr("response body", err)
+			}
+
+			body := result.Body
+			if result.Base64Encoded {
+				decoded, err := base64.StdEncoding.DecodeString(result.Body)
+				if err != nil {
+					return toolErr("decode response body", err)
+				}
+				body = string(decoded)
+			}
+
+			truncated := false
+			if len(body) > maxLength {
+				body = body[:maxLength]
+				truncated = true
+			}
+
+			var sb strings.Builder
+			sb.WriteString(fmt.Sprintf("Response body (request #%d):\n", int(index)))
+			sb.WriteString(body)
+			if truncated {
+				sb.WriteString(fmt.Sprintf("\n\n[truncated at %d characters]", maxLength))
+			}
+
+			return mcp.NewToolResultText(sb.String()), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)

--- a/tools/response_body_test.go
+++ b/tools/response_body_test.go
@@ -1,0 +1,49 @@
+package tools
+
+import "testing"
+
+func TestResponseBodyToolDefinition(t *testing.T) {
+	if ResponseBody.Name != ResponseBodyToolKey {
+		t.Errorf("ResponseBody tool name = %q, want %q", ResponseBody.Name, ResponseBodyToolKey)
+	}
+
+	props := ResponseBody.InputSchema.Properties
+	if props == nil {
+		t.Fatal("ResponseBody tool has no properties")
+	}
+
+	for _, param := range []string{"index", "maxLength"} {
+		if _, ok := props[param]; !ok {
+			t.Errorf("ResponseBody tool missing %q property", param)
+		}
+	}
+
+	// "index" should be required
+	found := false
+	for _, r := range ResponseBody.InputSchema.Required {
+		if r == "index" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("ResponseBody tool 'index' parameter should be required")
+	}
+}
+
+func TestResponseBodyToolRegistered(t *testing.T) {
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == ResponseBodyToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("ResponseBody tool not found in CommonTools")
+	}
+
+	if _, ok := CommonToolHandlers[ResponseBodyToolKey]; !ok {
+		t.Error("ResponseBodyHandler not found in CommonToolHandlers")
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -48,6 +48,9 @@ var (
 		Cookies,
 		Storage,
 		Permissions,
+		Intercept,
+		ResponseBody,
+		WebSocket,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		ConfigureToolKey:       ConfigureHandler,
@@ -77,6 +80,9 @@ var (
 		CookiesToolKey:         CookiesHandler,
 		StorageToolKey:         StorageHandler,
 		PermissionsToolKey:     PermissionsHandler,
+		InterceptToolKey:       InterceptHandler,
+		ResponseBodyToolKey:    ResponseBodyHandler,
+		WebSocketToolKey:       WebSocketHandler,
 	}
 )
 

--- a/tools/websocket.go
+++ b/tools/websocket.go
@@ -1,0 +1,100 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	WebSocketToolKey = "rod_websocket"
+)
+
+var (
+	WebSocket = mcp.NewTool(WebSocketToolKey,
+		mcp.WithDescription("Monitor WebSocket connections and their messages. Frames are captured automatically after rod_navigate."),
+		mcp.WithString("action", mcp.Description("Action to perform"), mcp.Required(), mcp.Enum("list", "frames", "clear")),
+		mcp.WithString("urlFilter", mcp.Description("Filter connections/frames by URL substring")),
+		mcp.WithString("direction", mcp.Description("Filter frames by direction"), mcp.Enum("sent", "received")),
+		mcp.WithNumber("maxFrames", mcp.Description("Maximum number of frames to return (default: 100)")),
+	)
+)
+
+var (
+	WebSocketHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := request.GetArguments()
+			action, err := getStringArg(args, "action")
+			if err != nil {
+				return toolErr("websocket", err)
+			}
+
+			switch action {
+			case "list":
+				connections := rodCtx.WebSocketConnections(getOptionalStringArg(args, "urlFilter"))
+				if len(connections) == 0 {
+					return mcp.NewToolResultText("No WebSocket connections captured"), nil
+				}
+
+				var sb strings.Builder
+				sb.WriteString(fmt.Sprintf("WebSocket connections (%d):\n", len(connections)))
+				for i, conn := range connections {
+					status := "open"
+					if conn.Closed {
+						status = "closed"
+					}
+					sb.WriteString(fmt.Sprintf("  %d. [%s] %s (frames: %d sent, %d received)\n",
+						i, status, conn.URL, conn.SentCount, conn.ReceivedCount))
+				}
+				return mcp.NewToolResultText(sb.String()), nil
+
+			case "frames":
+				urlFilter := getOptionalStringArg(args, "urlFilter")
+				direction := getOptionalStringArg(args, "direction")
+				maxFrames := int(getOptionalFloatArg(args, "maxFrames", 100))
+
+				frames := rodCtx.WebSocketFrames(urlFilter, direction)
+				if len(frames) == 0 {
+					return mcp.NewToolResultText("No WebSocket frames captured"), nil
+				}
+
+				total := len(frames)
+				if len(frames) > maxFrames {
+					frames = frames[len(frames)-maxFrames:]
+				}
+
+				var sb strings.Builder
+				if total > maxFrames {
+					sb.WriteString(fmt.Sprintf("WebSocket frames (showing last %d of %d):\n", maxFrames, total))
+				} else {
+					sb.WriteString(fmt.Sprintf("WebSocket frames (%d):\n", len(frames)))
+				}
+				for _, f := range frames {
+					dir := "→"
+					if f.Direction == "received" {
+						dir = "←"
+					}
+					payload := f.PayloadData
+					if len(payload) > 200 {
+						payload = payload[:200] + "..."
+					}
+					sb.WriteString(fmt.Sprintf("  %s [%s] %s\n", dir, f.URL, payload))
+				}
+				return mcp.NewToolResultText(sb.String()), nil
+
+			case "clear":
+				rodCtx.ClearWebSocketData()
+				return mcp.NewToolResultText("WebSocket data cleared"), nil
+
+			default:
+				return nil, fmt.Errorf("invalid action %q: must be list, frames, or clear", action)
+			}
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)

--- a/tools/websocket_test.go
+++ b/tools/websocket_test.go
@@ -1,0 +1,49 @@
+package tools
+
+import "testing"
+
+func TestWebSocketToolDefinition(t *testing.T) {
+	if WebSocket.Name != WebSocketToolKey {
+		t.Errorf("WebSocket tool name = %q, want %q", WebSocket.Name, WebSocketToolKey)
+	}
+
+	props := WebSocket.InputSchema.Properties
+	if props == nil {
+		t.Fatal("WebSocket tool has no properties")
+	}
+
+	for _, param := range []string{"action", "urlFilter", "direction", "maxFrames"} {
+		if _, ok := props[param]; !ok {
+			t.Errorf("WebSocket tool missing %q property", param)
+		}
+	}
+
+	// "action" should be required
+	found := false
+	for _, r := range WebSocket.InputSchema.Required {
+		if r == "action" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("WebSocket tool 'action' parameter should be required")
+	}
+}
+
+func TestWebSocketToolRegistered(t *testing.T) {
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == WebSocketToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("WebSocket tool not found in CommonTools")
+	}
+
+	if _, ok := CommonToolHandlers[WebSocketToolKey]; !ok {
+		t.Error("WebSocketHandler not found in CommonToolHandlers")
+	}
+}

--- a/types/context.go
+++ b/types/context.go
@@ -179,10 +179,38 @@ type ConsoleMessage struct {
 
 // NetworkRequest represents a captured network request with its response.
 type NetworkRequest struct {
-	Method string `json:"method"`
-	URL    string `json:"url"`
-	Status int    `json:"status"`
-	Type   string `json:"type"`
+	RequestID string `json:"requestId"`
+	Method    string `json:"method"`
+	URL       string `json:"url"`
+	Status    int    `json:"status"`
+	Type      string `json:"type"`
+}
+
+// InterceptRule defines a rule for how to handle an intercepted request.
+type InterceptRule struct {
+	URLPattern  string
+	Action      string // "mock", "block", "fail"
+	Status      int
+	Headers     []*proto.FetchHeaderEntry
+	Body        []byte
+	ErrorReason proto.NetworkErrorReason
+}
+
+// WebSocketConnection represents a tracked WebSocket connection.
+type WebSocketConnection struct {
+	RequestID     string `json:"requestId"`
+	URL           string `json:"url"`
+	Closed        bool   `json:"closed"`
+	SentCount     int    `json:"sentCount"`
+	ReceivedCount int    `json:"receivedCount"`
+}
+
+// WebSocketFrame represents a single captured WebSocket message.
+type WebSocketFrame struct {
+	URL         string `json:"url"`
+	Direction   string `json:"direction"` // "sent" or "received"
+	PayloadData string `json:"payloadData"`
+	Opcode      int    `json:"opcode"`
 }
 
 type Context struct {
@@ -197,6 +225,13 @@ type Context struct {
 	networkRequests []NetworkRequest
 	// pendingRequests tracks in-flight requests by ID for response correlation.
 	pendingRequests map[string]int
+	// Intercept state
+	interceptRules   []InterceptRule
+	interceptEnabled bool
+	// WebSocket tracking
+	wsConnections []WebSocketConnection
+	wsConnIndex   map[string]int // requestID → index in wsConnections
+	wsFrames      []WebSocketFrame
 	// clonedProfileDir is the temp directory from profile cloning, cleaned up on Close.
 	clonedProfileDir string
 }
@@ -400,9 +435,10 @@ func (ctx *Context) attachEventListeners(page *rod.Page) {
 		}
 		idx := len(ctx.networkRequests)
 		ctx.networkRequests = append(ctx.networkRequests, NetworkRequest{
-			Method: e.Request.Method,
-			URL:    e.Request.URL,
-			Type:   string(e.Type),
+			RequestID: string(e.RequestID),
+			Method:    e.Request.Method,
+			URL:       e.Request.URL,
+			Type:      string(e.Type),
 		})
 		ctx.pendingRequests[string(e.RequestID)] = idx
 		ctx.stateLock.Unlock()
@@ -412,6 +448,37 @@ func (ctx *Context) attachEventListeners(page *rod.Page) {
 			ctx.networkRequests[idx].Status = e.Response.Status
 			ctx.networkRequests[idx].Type = string(e.Type)
 			delete(ctx.pendingRequests, string(e.RequestID))
+		}
+		ctx.stateLock.Unlock()
+	}, func(e *proto.NetworkWebSocketCreated) {
+		ctx.stateLock.Lock()
+		if ctx.wsConnIndex == nil {
+			ctx.wsConnIndex = make(map[string]int)
+		}
+		ctx.wsConnIndex[string(e.RequestID)] = len(ctx.wsConnections)
+		ctx.wsConnections = append(ctx.wsConnections, WebSocketConnection{
+			RequestID: string(e.RequestID),
+			URL:       e.URL,
+		})
+		ctx.stateLock.Unlock()
+	}, func(e *proto.NetworkWebSocketFrameSent) {
+		ctx.stateLock.Lock()
+		if idx, ok := ctx.wsConnIndex[string(e.RequestID)]; ok {
+			ctx.wsConnections[idx].SentCount++
+			ctx.appendWSFrame(ctx.wsConnections[idx].URL, "sent", e.Response)
+		}
+		ctx.stateLock.Unlock()
+	}, func(e *proto.NetworkWebSocketFrameReceived) {
+		ctx.stateLock.Lock()
+		if idx, ok := ctx.wsConnIndex[string(e.RequestID)]; ok {
+			ctx.wsConnections[idx].ReceivedCount++
+			ctx.appendWSFrame(ctx.wsConnections[idx].URL, "received", e.Response)
+		}
+		ctx.stateLock.Unlock()
+	}, func(e *proto.NetworkWebSocketClosed) {
+		ctx.stateLock.Lock()
+		if idx, ok := ctx.wsConnIndex[string(e.RequestID)]; ok {
+			ctx.wsConnections[idx].Closed = true
 		}
 		ctx.stateLock.Unlock()
 	})()
@@ -471,6 +538,114 @@ func (ctx *Context) NetworkRequests(filterURL, filterMethod string, clear bool) 
 	}
 
 	return result
+}
+
+const maxWSFrames = 10000
+
+// appendWSFrame adds a WebSocket frame, dropping the oldest if the buffer is full.
+// Must be called with stateLock held.
+func (ctx *Context) appendWSFrame(url, direction string, frame *proto.NetworkWebSocketFrame) {
+	if len(ctx.wsFrames) >= maxWSFrames {
+		// Drop oldest 10% to avoid frequent shifting
+		drop := maxWSFrames / 10
+		copy(ctx.wsFrames, ctx.wsFrames[drop:])
+		ctx.wsFrames = ctx.wsFrames[:len(ctx.wsFrames)-drop]
+	}
+	ctx.wsFrames = append(ctx.wsFrames, WebSocketFrame{
+		URL:         url,
+		Direction:   direction,
+		PayloadData: frame.PayloadData,
+		Opcode:      int(frame.Opcode),
+	})
+}
+
+// InterceptEnabled returns whether request interception is currently enabled.
+func (ctx *Context) InterceptEnabled() bool {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+	return ctx.interceptEnabled
+}
+
+// SetInterceptEnabled sets whether interception is enabled.
+func (ctx *Context) SetInterceptEnabled(enabled bool) {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+	ctx.interceptEnabled = enabled
+	if !enabled {
+		ctx.interceptRules = nil
+	}
+}
+
+// AddInterceptRule appends an interception rule.
+func (ctx *Context) AddInterceptRule(rule InterceptRule) {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+	ctx.interceptRules = append(ctx.interceptRules, rule)
+}
+
+// InterceptRules returns a copy of the current interception rules.
+func (ctx *Context) InterceptRules() []InterceptRule {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+	rules := make([]InterceptRule, len(ctx.interceptRules))
+	copy(rules, ctx.interceptRules)
+	return rules
+}
+
+// GetRequestID returns the CDP request ID for a network request at the given index.
+func (ctx *Context) GetRequestID(index int) (string, error) {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	if len(ctx.networkRequests) == 0 {
+		return "", fmt.Errorf("no network requests captured")
+	}
+	if index < 0 || index >= len(ctx.networkRequests) {
+		return "", fmt.Errorf("request index %d out of range (0-%d)", index, len(ctx.networkRequests)-1)
+	}
+	return ctx.networkRequests[index].RequestID, nil
+}
+
+// WebSocketConnections returns tracked WebSocket connections, optionally filtered by URL.
+func (ctx *Context) WebSocketConnections(urlFilter string) []WebSocketConnection {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	var result []WebSocketConnection
+	for _, conn := range ctx.wsConnections {
+		if urlFilter != "" && !strings.Contains(conn.URL, urlFilter) {
+			continue
+		}
+		result = append(result, conn)
+	}
+	return result
+}
+
+// WebSocketFrames returns captured WebSocket frames, optionally filtered by URL and direction.
+func (ctx *Context) WebSocketFrames(urlFilter, direction string) []WebSocketFrame {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	var result []WebSocketFrame
+	for _, f := range ctx.wsFrames {
+		if urlFilter != "" && !strings.Contains(f.URL, urlFilter) {
+			continue
+		}
+		if direction != "" && f.Direction != direction {
+			continue
+		}
+		result = append(result, f)
+	}
+	return result
+}
+
+// ClearWebSocketData clears all WebSocket connections and frames.
+func (ctx *Context) ClearWebSocketData() {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+	ctx.wsConnections = nil
+	ctx.wsConnIndex = nil
+	ctx.wsFrames = nil
 }
 
 // TabInfo represents a tab's metadata for listing.


### PR DESCRIPTION
## Summary
- **rod_intercept** (#99): Mock, block, or fail network requests via CDP Fetch domain with wildcard URL pattern matching and per-context rule state
- **rod_response_body** (#105): Retrieve response bodies for captured network requests via CDP Network.getResponseBody with base64 decoding and truncation
- **rod_websocket** (#104): Monitor WebSocket connections and frames with automatic capture via CDP Network.webSocket* events, bounded frame buffer (10k max)

## Changes
- `tools/intercept.go` — Request interception with enable/mock/block/fail/disable/list actions
- `tools/response_body.go` — Response body retrieval by request index
- `tools/websocket.go` — WebSocket connection listing and frame inspection
- `types/context.go` — InterceptRule type, WebSocket types, event listeners, GetRequestID, frame buffer with 10k cap
- `tools/tools.go` — Register all three new tools
- Tests for all new tools

## Review findings addressed
- Moved intercept state from global singleton to per-Context (session isolation)
- Log CDP errors in Fetch event handlers instead of silently discarding
- Guard mock/block/fail actions to require `enable` first
- Fixed double base64 encoding in mock body (rod marshals `[]byte` automatically)
- Bounded WebSocket frame buffer at 10k entries
- Deterministic WebSocket connection ordering via slice
- Clear error message for empty network requests in GetRequestID

Closes #99, #105, #104