### PR TITLE
feat: add rod_performance, rod_drag, and expand rod_resize

### DIFF
--- a/tools/browser.go
+++ b/tools/browser.go
@@ -33,11 +33,13 @@ var (
 		mcp.WithObject("headers", mcp.Description("Headers as key-value pairs, e.g. {\"Authorization\": \"Bearer token\", \"X-Custom-Header\": \"value\"}"), mcp.Required()),
 	)
 	Resize = mcp.NewTool(ResizeToolKey,
-		mcp.WithDescription("Set the browser viewport dimensions for responsive testing and layout control"),
+		mcp.WithDescription("Set browser viewport dimensions and emulate device characteristics. Supports full device emulation with user agent, touch, and DPR override."),
 		mcp.WithNumber("width", mcp.Description("Viewport width in pixels"), mcp.Required()),
 		mcp.WithNumber("height", mcp.Description("Viewport height in pixels"), mcp.Required()),
 		mcp.WithNumber("device_scale_factor", mcp.Description("Device pixel ratio (default: 1)")),
 		mcp.WithBoolean("is_mobile", mcp.Description("Emulate mobile viewport (default: false)")),
+		mcp.WithString("user_agent", mcp.Description("Override the browser User-Agent string")),
+		mcp.WithBoolean("has_touch", mcp.Description("Enable touch event emulation (default: false)")),
 	)
 	HandleDialog = mcp.NewTool(HandleDialogToolKey,
 		mcp.WithDescription("Handle a JavaScript dialog (alert, confirm, prompt). Use this when a dialog is blocking page interaction."),
@@ -140,7 +142,32 @@ var (
 			if err != nil {
 				return toolErr("resize viewport", err)
 			}
-			return mcp.NewToolResultText(fmt.Sprintf("Viewport resized to %dx%d (scale: %.1f, mobile: %t)", width, height, deviceScaleFactor, mobile)), nil
+
+			userAgent := getOptionalStringArg(request.GetArguments(), "user_agent")
+			if userAgent != "" {
+				if err := (proto.EmulationSetUserAgentOverride{
+					UserAgent: userAgent,
+				}).Call(page); err != nil {
+					return toolErr("set user agent", err)
+				}
+			}
+
+			hasTouch := getOptionalBoolArg(request.GetArguments(), "has_touch", false)
+			if err := (proto.EmulationSetTouchEmulationEnabled{
+				Enabled: hasTouch,
+			}).Call(page); err != nil {
+				return toolErr("set touch emulation", err)
+			}
+
+			msg := fmt.Sprintf("Viewport resized to %dx%d (scale: %.1f, mobile: %t", width, height, deviceScaleFactor, mobile)
+			if userAgent != "" {
+				msg += ", ua: custom"
+			}
+			if hasTouch {
+				msg += ", touch: on"
+			}
+			msg += ")"
+			return mcp.NewToolResultText(msg), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}

--- a/tools/drag.go
+++ b/tools/drag.go
@@ -1,0 +1,153 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	DragToolKey = "rod_drag"
+)
+
+var (
+	Drag = mcp.NewTool(DragToolKey,
+		mcp.WithDescription("Perform drag-and-drop interactions by specifying source and target coordinates or CSS selectors. Simulates mouse press, move, and release."),
+		mcp.WithNumber("startX", mcp.Description("Source X coordinate in CSS pixels")),
+		mcp.WithNumber("startY", mcp.Description("Source Y coordinate in CSS pixels")),
+		mcp.WithNumber("endX", mcp.Description("Target X coordinate in CSS pixels")),
+		mcp.WithNumber("endY", mcp.Description("Target Y coordinate in CSS pixels")),
+		mcp.WithString("sourceSelector", mcp.Description("CSS selector for the source element (alternative to startX/startY)")),
+		mcp.WithString("targetSelector", mcp.Description("CSS selector for the target element (alternative to endX/endY)")),
+		mcp.WithNumber("steps", mcp.Description("Number of intermediate mouse move steps (default: 10)")),
+	)
+)
+
+// resolvePosition resolves X/Y coordinates from either a CSS selector or explicit coordinate args.
+func resolvePosition(page *rod.Page, args map[string]interface{}, selectorKey, xKey, yKey string) (float64, float64, error) {
+	selector := getOptionalStringArg(args, selectorKey)
+	if selector != "" {
+		el, err := page.Element(selector)
+		if err != nil {
+			return 0, 0, fmt.Errorf("find element %q: %w", selector, err)
+		}
+		shape, err := el.Shape()
+		if err != nil {
+			return 0, 0, fmt.Errorf("get element bounds for %q: %w", selector, err)
+		}
+		rect := shape.Box()
+		if rect == nil {
+			return 0, 0, fmt.Errorf("element %q has no visible bounds", selector)
+		}
+		return rect.X + rect.Width/2, rect.Y + rect.Height/2, nil
+	}
+
+	x, err := getFloatArg(args, xKey)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%s or %s required", xKey, selectorKey)
+	}
+	y, err := getFloatArg(args, yKey)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%s or %s required", yKey, selectorKey)
+	}
+	return x, y, nil
+}
+
+var (
+	DragHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("drag", err)
+			}
+
+			args := request.GetArguments()
+			steps := int(getOptionalFloatArg(args, "steps", 10))
+			if steps < 1 {
+				steps = 1
+			}
+
+			startX, startY, err := resolvePosition(page, args, "sourceSelector", "startX", "startY")
+			if err != nil {
+				return toolErr("drag source", err)
+			}
+
+			endX, endY, err := resolvePosition(page, args, "targetSelector", "endX", "endY")
+			if err != nil {
+				return toolErr("drag target", err)
+			}
+
+			// Move to start position
+			if err := (proto.InputDispatchMouseEvent{
+				Type: proto.InputDispatchMouseEventTypeMouseMoved,
+				X:    startX,
+				Y:    startY,
+			}).Call(page); err != nil {
+				return toolErr("move to start", err)
+			}
+
+			// Press at start
+			if err := (proto.InputDispatchMouseEvent{
+				Type:       proto.InputDispatchMouseEventTypeMousePressed,
+				X:          startX,
+				Y:          startY,
+				Button:     proto.InputMouseButtonLeft,
+				ClickCount: 1,
+			}).Call(page); err != nil {
+				return toolErr("mouse press", err)
+			}
+
+			// Ensure mouse is released even if move steps fail
+			mouseReleased := false
+			defer func() {
+				if !mouseReleased {
+					_ = (proto.InputDispatchMouseEvent{
+						Type:       proto.InputDispatchMouseEventTypeMouseReleased,
+						X:          endX,
+						Y:          endY,
+						Button:     proto.InputMouseButtonLeft,
+						ClickCount: 1,
+					}).Call(page)
+				}
+			}()
+
+			// Move in steps
+			for i := 1; i <= steps; i++ {
+				t := float64(i) / float64(steps)
+				x := startX + (endX-startX)*t
+				y := startY + (endY-startY)*t
+				if err := (proto.InputDispatchMouseEvent{
+					Type:   proto.InputDispatchMouseEventTypeMouseMoved,
+					X:      x,
+					Y:      y,
+					Button: proto.InputMouseButtonLeft,
+				}).Call(page); err != nil {
+					return toolErr("mouse move", err)
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			// Release at end
+			if err := (proto.InputDispatchMouseEvent{
+				Type:       proto.InputDispatchMouseEventTypeMouseReleased,
+				X:          endX,
+				Y:          endY,
+				Button:     proto.InputMouseButtonLeft,
+				ClickCount: 1,
+			}).Call(page); err != nil {
+				return toolErr("mouse release", err)
+			}
+			mouseReleased = true
+
+			return mcp.NewToolResultText(fmt.Sprintf("Dragged from (%.0f, %.0f) to (%.0f, %.0f) in %d steps", startX, startY, endX, endY, steps)), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
+	}
+)

--- a/tools/drag_test.go
+++ b/tools/drag_test.go
@@ -1,0 +1,37 @@
+package tools
+
+import "testing"
+
+func TestDragToolDefinition(t *testing.T) {
+	if Drag.Name != DragToolKey {
+		t.Errorf("Drag tool name = %q, want %q", Drag.Name, DragToolKey)
+	}
+
+	props := Drag.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Drag tool has no properties")
+	}
+
+	for _, param := range []string{"startX", "startY", "endX", "endY", "sourceSelector", "targetSelector", "steps"} {
+		if _, ok := props[param]; !ok {
+			t.Errorf("Drag tool missing %q property", param)
+		}
+	}
+}
+
+func TestDragToolRegistered(t *testing.T) {
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == DragToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Drag tool not found in CommonTools")
+	}
+
+	if _, ok := CommonToolHandlers[DragToolKey]; !ok {
+		t.Error("DragHandler not found in CommonToolHandlers")
+	}
+}

--- a/tools/performance.go
+++ b/tools/performance.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	PerformanceToolKey = "rod_performance"
+)
+
+var (
+	Performance = mcp.NewTool(PerformanceToolKey,
+		mcp.WithDescription("Collect browser performance metrics and Core Web Vitals. Returns CDP Performance domain metrics and optionally web vitals (LCP, CLS, FID, TTFB) via JS evaluation."),
+		mcp.WithString("action", mcp.Description("Action to perform"), mcp.Required(), mcp.Enum("metrics", "vitals")),
+	)
+)
+
+var (
+	PerformanceHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("performance", err)
+			}
+
+			action, err := getStringArg(request.GetArguments(), "action")
+			if err != nil {
+				return toolErr("performance", err)
+			}
+
+			switch action {
+			case "metrics":
+				err = proto.PerformanceEnable{}.Call(page)
+				if err != nil {
+					return toolErr("enable performance", err)
+				}
+				result, err := proto.PerformanceGetMetrics{}.Call(page)
+				if err != nil {
+					return toolErr("get performance metrics", err)
+				}
+
+				sort.Slice(result.Metrics, func(i, j int) bool {
+					return result.Metrics[i].Name < result.Metrics[j].Name
+				})
+
+				var sb strings.Builder
+				sb.WriteString(fmt.Sprintf("Performance metrics (%d):\n", len(result.Metrics)))
+				for _, m := range result.Metrics {
+					if m.Value == float64(int64(m.Value)) {
+						sb.WriteString(fmt.Sprintf("  %s: %d\n", m.Name, int64(m.Value)))
+					} else {
+						sb.WriteString(fmt.Sprintf("  %s: %.3f\n", m.Name, m.Value))
+					}
+				}
+				return mcp.NewToolResultText(sb.String()), nil
+
+			case "vitals":
+				r, err := page.Eval(`() => {
+					const result = {};
+					const entries = performance.getEntriesByType('navigation');
+					if (entries.length > 0) {
+						const nav = entries[0];
+						result.ttfb = Math.round(nav.responseStart - nav.requestStart);
+						result.domContentLoaded = Math.round(nav.domContentLoadedEventEnd - nav.startTime);
+						result.load = Math.round(nav.loadEventEnd - nav.startTime);
+						result.domInteractive = Math.round(nav.domInteractive - nav.startTime);
+					}
+					const paintEntries = performance.getEntriesByType('paint');
+					for (const entry of paintEntries) {
+						if (entry.name === 'first-paint') result.fp = Math.round(entry.startTime);
+						if (entry.name === 'first-contentful-paint') result.fcp = Math.round(entry.startTime);
+					}
+					const lcpEntries = performance.getEntriesByType('largest-contentful-paint');
+					if (lcpEntries.length > 0) {
+						result.lcp = Math.round(lcpEntries[lcpEntries.length - 1].startTime);
+					}
+					const layoutShifts = performance.getEntriesByType('layout-shift');
+					let cls = 0;
+					for (const entry of layoutShifts) {
+						if (!entry.hadRecentInput) cls += entry.value;
+					}
+					result.cls = Math.round(cls * 1000) / 1000;
+					return JSON.stringify(result);
+				}`)
+				if err != nil {
+					return toolErr("get web vitals", err)
+				}
+
+				return mcp.NewToolResultText(fmt.Sprintf("Web Vitals:\n%s", r.Value.Str())), nil
+
+			default:
+				return nil, fmt.Errorf("invalid action %q: must be metrics or vitals", action)
+			}
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)

--- a/tools/performance_test.go
+++ b/tools/performance_test.go
@@ -1,0 +1,47 @@
+package tools
+
+import "testing"
+
+func TestPerformanceToolDefinition(t *testing.T) {
+	if Performance.Name != PerformanceToolKey {
+		t.Errorf("Performance tool name = %q, want %q", Performance.Name, PerformanceToolKey)
+	}
+
+	props := Performance.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Performance tool has no properties")
+	}
+
+	if _, ok := props["action"]; !ok {
+		t.Error("Performance tool missing 'action' property")
+	}
+
+	// "action" should be required
+	found := false
+	for _, r := range Performance.InputSchema.Required {
+		if r == "action" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Performance tool 'action' parameter should be required")
+	}
+}
+
+func TestPerformanceToolRegistered(t *testing.T) {
+	found := false
+	for _, tool := range CommonTools {
+		if tool.Name == PerformanceToolKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Performance tool not found in CommonTools")
+	}
+
+	if _, ok := CommonToolHandlers[PerformanceToolKey]; !ok {
+		t.Error("PerformanceHandler not found in CommonToolHandlers")
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -51,6 +51,8 @@ var (
 		Intercept,
 		ResponseBody,
 		WebSocket,
+		Performance,
+		Drag,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		ConfigureToolKey:       ConfigureHandler,
@@ -83,6 +85,8 @@ var (
 		InterceptToolKey:       InterceptHandler,
 		ResponseBodyToolKey:    ResponseBodyHandler,
 		WebSocketToolKey:       WebSocketHandler,
+		PerformanceToolKey:     PerformanceHandler,
+		DragToolKey:            DragHandler,
 	}
 )
 


### PR DESCRIPTION
## Summary
- **rod_performance** (#103): Collect CDP Performance domain metrics and Web Vitals (LCP, CLS, FCP, TTFB) via JS evaluation
- **rod_drag** (#106): Drag-and-drop via mouse press/move/release with CSS selector or coordinate targeting, configurable step count, deferred mouse release for cleanup on failure
- **rod_resize expansion** (#102): Added `user_agent` override via CDP Emulation.setUserAgentOverride and bidirectional `has_touch` emulation

## Changes
- `tools/performance.go` — Performance metrics and web vitals tool
- `tools/drag.go` — Drag-and-drop with `resolvePosition` helper for DRY selector/coordinate resolution
- `tools/browser.go` — Enhanced resize with user agent and touch emulation params
- `tools/tools.go` — Register new tools
- Tests for all new tools

## Review findings addressed
- Nil-check on `Shape.Box()` return to prevent panic on invisible elements
- Deferred mouse release in drag handler to avoid stuck button state on error
- Bidirectional touch emulation (explicitly disabled when `has_touch=false`)
- Extracted `resolvePosition` helper to eliminate duplicated selector resolution logic

Closes #102, #103, #106