### PR TITLE
fix: reliable dialog handling via event listener

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -286,10 +286,11 @@ func truncate(s string, n int) string {
 }
 
 // navigate navigates to a URL and waits for the page body to be visible.
+// Uses a longer timeout to accommodate browser launch on first navigation.
 func (h *harness) navigate(url string) string {
 	h.t.Helper()
-	result := h.call("rod_navigate", map[string]any{"url": url})
-	h.call("rod_wait_for", map[string]any{"selector": "body", "timeout": 10000})
+	result := h.callWithTimeout("rod_navigate", map[string]any{"url": url}, 30*time.Second)
+	h.callWithTimeout("rod_wait_for", map[string]any{"selector": "body", "timeout": 15000}, 20*time.Second)
 	return result
 }
 
@@ -681,11 +682,29 @@ func TestE2E(t *testing.T) {
 	t.Run("handle_dialog", func(t *testing.T) {
 		h.navigate("https://the-internet.herokuapp.com/javascript_alerts")
 
-		// Dialog handling has a race condition — Chrome auto-dismisses alerts
-		// when no Page.javascriptDialogOpening listener is active.
-		// Verify the tool accepts valid params and returns a coherent response.
-		result := h.call("rod_handle_dialog", map[string]any{"action": "accept"})
-		assertContainsAny(t, result, "Dialog accepted", "No dialog is showing")
+		// rod_handle_dialog sets up a listener and blocks until a dialog appears.
+		// Send it first, then trigger the dialog — MCP processes requests concurrently.
+		handleID := h.send("tools/call", map[string]any{
+			"name":      "rod_handle_dialog",
+			"arguments": map[string]any{"action": "accept"},
+		})
+
+		// Trigger the alert (this will also block until dialog is dismissed).
+		clickID := h.send("tools/call", map[string]any{
+			"name":      "rod_evaluate",
+			"arguments": map[string]any{"script": `() => { document.querySelector("button[onclick='jsAlert()']").click(); return "clicked"; }`},
+		})
+
+		// handle_dialog should complete once the dialog is accepted.
+		handleResp := h.recv(handleID, 10*time.Second)
+		handleResult := h.extractText(handleResp)
+		assertContains(t, handleResult, "Dialog accepted successfully")
+		assertContains(t, handleResult, "alert")
+
+		// The evaluate call should now complete too.
+		clickResp := h.recv(clickID, 5*time.Second)
+		clickResult := h.extractText(clickResp)
+		assertContains(t, clickResult, "clicked")
 	})
 
 	t.Run("intercept_live_mock", func(t *testing.T) {

--- a/tools/browser.go
+++ b/tools/browser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -42,7 +43,7 @@ var (
 		mcp.WithBoolean("has_touch", mcp.Description("Enable touch event emulation (default: false)")),
 	)
 	HandleDialog = mcp.NewTool(HandleDialogToolKey,
-		mcp.WithDescription("Handle a JavaScript dialog (alert, confirm, prompt). Use this when a dialog is blocking page interaction."),
+		mcp.WithDescription("Handle a JavaScript dialog (alert, confirm, prompt). Call BEFORE triggering the dialog — sets up a listener that auto-handles the next dialog that appears. Returns dialog info once handled."),
 		mcp.WithString("action", mcp.Description("accept or dismiss"), mcp.Required()),
 		mcp.WithString("text", mcp.Description("Text to enter for prompt() dialogs before accepting")),
 	)
@@ -193,14 +194,35 @@ var (
 				promptText = t
 			}
 
-			err = proto.PageHandleJavaScriptDialog{
-				Accept:     accept,
-				PromptText: promptText,
-			}.Call(page)
-			if err != nil {
-				return toolErr("handle dialog", err)
+			// Use rod's HandleDialog which registers a Page.javascriptDialogOpening
+			// listener. This blocks until a dialog appears, then handles it.
+			wait, handle := page.HandleDialog()
+
+			// Wait for the dialog in a goroutine with a timeout.
+			type dialogResult struct {
+				evt *proto.PageJavascriptDialogOpening
 			}
-			return mcp.NewToolResultText(fmt.Sprintf("Dialog %sed successfully", action)), nil
+			ch := make(chan dialogResult, 1)
+			go func() {
+				evt := wait()
+				ch <- dialogResult{evt: evt}
+			}()
+
+			select {
+			case dr := <-ch:
+				err = handle(&proto.PageHandleJavaScriptDialog{
+					Accept:     accept,
+					PromptText: promptText,
+				})
+				if err != nil {
+					return toolErr("handle dialog", err)
+				}
+				msg := fmt.Sprintf("Dialog %sed successfully (type: %s, message: %q)",
+					action, dr.evt.Type, dr.evt.Message)
+				return mcp.NewToolResultText(msg), nil
+			case <-time.After(30 * time.Second):
+				return mcp.NewToolResultText("No dialog appeared within timeout"), nil
+			}
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}


### PR DESCRIPTION
## Summary

- Rewrites `rod_handle_dialog` to use rod's `page.HandleDialog()` which registers a `Page.javascriptDialogOpening` event listener
- The handler now blocks until a dialog appears (up to 30s timeout), then accepts/dismisses it
- Returns dialog metadata (type, message) in the response
- Eliminates the race condition where Chrome auto-dismissed dialogs before the handler could process them

## Changes

- **`tools/browser.go`**: Handler uses `page.HandleDialog()` → `wait()` (blocks for dialog) → `handle()` (accepts/dismisses). Goroutine + channel pattern enforces timeout.
- **`e2e/e2e_test.go`**: Dialog test sends `rod_handle_dialog` before triggering the alert, leveraging MCP's concurrent request processing. Also increases navigate timeout for slower browser launches.

## Test plan

- [x] `go test ./...` — unit tests pass
- [x] `go test -tags e2e -v -timeout 300s ./e2e/` — all 68 subtests pass (20s), including `handle_dialog`
- [x] `go vet ./...` — clean

Closes #116