### PR TITLE
fix: write banner to stderr instead of stdout

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -99,7 +99,7 @@ func RunCmd() (*SubCfg, error) {
 		},
 		Before: func(c *cli.Context) error {
 			if !c.Bool("no-banner") {
-				fmt.Println(banner.ShowBanner())
+				fmt.Fprintln(os.Stderr, banner.ShowBanner())
 			}
 
 			return nil


### PR DESCRIPTION
## Summary
- Banner was printed to stdout via `fmt.Println()`, corrupting the MCP stdio JSON-RPC stream
- MCP clients read the banner as the first message, failed to parse it, and reported EOF
- Changed to `fmt.Fprintln(os.Stderr, ...)` so banner goes to stderr without interfering with the protocol

Closes #156