### PR TITLE
chore: detach from upstream go-rod/rod-mcp

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Go Rod Team (https://github.com/go-rod/rod-mcp)
+Copyright (c) 2024 Go Rod Team
 Copyright (c) 2025 Ali Watters
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -331,10 +331,6 @@ rod-mcp/
 └── assets/          # Logo images
 ```
 
-## Attribution
-
-This project is a fork of [go-rod/rod-mcp](https://github.com/go-rod/rod-mcp) by the Go Rod Team. The original project provided the foundation for browser automation via the Model Context Protocol.
-
 ## License
 
 MIT - see [LICENSE](LICENSE)

--- a/README_CN.md
+++ b/README_CN.md
@@ -198,10 +198,6 @@ go build -o rod-mcp .
 - Go 1.23+
 - Chrome 或 Chromium
 
-## 归属
-
-本项目是 Go Rod Team 的 [go-rod/rod-mcp](https://github.com/go-rod/rod-mcp) 的分支。原项目为通过 Model Context Protocol 实现浏览器自动化奠定了基础。
-
 ## 许可证
 
 MIT - 详见 [LICENSE](LICENSE)


### PR DESCRIPTION
## Summary

- Remove Attribution sections from README.md and README_CN.md that referenced go-rod/rod-mcp as the upstream fork
- Remove dead upstream URL from LICENSE copyright line (preserves original Go Rod Team copyright as required by MIT)
- No code changes; all `go-rod/rod` library references (the actual Rod dependency) are correctly preserved

Closes #188