### PR TITLE
feat: add auto-merge workflow (Closes #191)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,29 @@
+name: Auto-Merge PRs
+
+on:
+  check_suite:
+    types: [completed]
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success') ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'automerge')
+    steps:
+      - uses: aliwatters/auto-merge-pr@v1
+        with:
+          merge-method: squash
+          required-labels: "automerge"
+          exclude-labels: "no-automerge"

--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -24,3 +24,4 @@ jobs:
           update-mode: "next"
           cancel-stale-ci: "true"
           conflict-label: "needs-rebase"
+          filter: "auto-merge+label"


### PR DESCRIPTION
## Summary

- Adds `auto-merge.yml` workflow that squash-merges PRs with the `automerge` label once CI passes
- Uses `aliwatters/auto-merge-pr@v1` with `no-automerge` label opt-out
- Updates `auto-update-branches.yml` to only update automerge-labeled PR branches

## Why

Agent-created PRs that pass CI sit waiting for manual merge. This automates the merge step for labeled PRs, reducing toil while preserving manual control via labels.

## Test plan

- [ ] Add `automerge` label to a PR with passing CI — verify it gets squash-merged
- [ ] Verify PRs without the label are not auto-merged
- [ ] Add `no-automerge` label to a PR with `automerge` — verify it's excluded