### PR TITLE
feat: right-click, double-click, and keyboard modifier combos

### DIFF
--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -220,3 +220,26 @@ func parseKey(keyStr string) (input.Key, error) {
 
 	return 0, fmt.Errorf("unknown key: %s", keyStr)
 }
+
+// modifierMap maps lowercase modifier names to input.Key constants.
+var modifierMap = map[string]input.Key{
+	"control": input.ControlLeft,
+	"ctrl":    input.ControlLeft,
+	"shift":   input.ShiftLeft,
+	"alt":     input.AltLeft,
+	"meta":    input.MetaLeft,
+	"command": input.MetaLeft,
+}
+
+// parseModifier converts a modifier string to an input.Key.
+func parseModifier(mod string) (input.Key, error) {
+	if key, ok := modifierMap[strings.ToLower(mod)]; ok {
+		return key, nil
+	}
+	return 0, fmt.Errorf("unknown modifier %q: must be control, shift, alt, or meta", mod)
+}
+
+// joinModifiers joins modifier names with "+" for display.
+func joinModifiers(mods []string) string {
+	return strings.Join(mods, "+")
+}

--- a/tools/input.go
+++ b/tools/input.go
@@ -23,8 +23,9 @@ const (
 
 var (
 	PressKey = mcp.NewTool(PressKeyToolKey,
-		mcp.WithDescription("Press a key on the keyboard"),
+		mcp.WithDescription("Press a key on the keyboard, optionally with modifier keys (Ctrl, Shift, Alt, Meta)"),
 		mcp.WithString("key", mcp.Description("Name of the key to press or a character to generate, such as `ArrowLeft` or `a`"), mcp.Required()),
+		mcp.WithArray("modifiers", mcp.Description("Modifier keys to hold: control, shift, alt, meta"), mcp.Items(map[string]interface{}{"type": "string"})),
 	)
 	Type = mcp.NewTool(TypeToolKey,
 		mcp.WithDescription("Type a string of text character by character with realistic keyboard events. Better than rod_fill for React controlled inputs. Use this instead of multiple rod_press calls."),
@@ -48,7 +49,8 @@ var (
 			if err != nil {
 				return toolErr("press key", err)
 			}
-			keyStr, err := getStringArg(request.GetArguments(), "key")
+			args := request.GetArguments()
+			keyStr, err := getStringArg(args, "key")
 			if err != nil {
 				return toolErr("press key", err)
 			}
@@ -56,11 +58,47 @@ var (
 			if err != nil {
 				return toolErr("parse key "+keyStr, err)
 			}
-			if err = page.Keyboard.Press(key); err != nil {
-				return toolErr("press key "+keyStr, err)
+
+			// Parse modifier keys
+			modifiers, err := utils.OptionalStringArrayParam(request, "modifiers")
+			if err != nil {
+				return toolErr("parse modifiers", err)
 			}
+
+			if len(modifiers) > 0 {
+				// Press modifiers down
+				for _, mod := range modifiers {
+					modKey, modErr := parseModifier(mod)
+					if modErr != nil {
+						return toolErr("press modifier", modErr)
+					}
+					if err = page.Keyboard.Press(modKey); err != nil {
+						return toolErr("press modifier "+mod, err)
+					}
+				}
+				// Type the key
+				if err = page.Keyboard.Type(key); err != nil {
+					return toolErr("type key "+keyStr, err)
+				}
+				// Release modifiers in reverse order
+				for i := len(modifiers) - 1; i >= 0; i-- {
+					modKey, _ := parseModifier(modifiers[i])
+					if err = page.Keyboard.Release(modKey); err != nil {
+						return toolErr("release modifier "+modifiers[i], err)
+					}
+				}
+			} else {
+				if err = page.Keyboard.Press(key); err != nil {
+					return toolErr("press key "+keyStr, err)
+				}
+			}
+
 			waitDOMStable(page)
-			return mcp.NewToolResultText(fmt.Sprintf("Press key %s successfully", keyStr)), nil
+			desc := keyStr
+			if len(modifiers) > 0 {
+				desc = fmt.Sprintf("%s+%s", joinModifiers(modifiers), keyStr)
+			}
+			return mcp.NewToolResultText(fmt.Sprintf("Press key %s successfully", desc)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: rodCtx.CurrentMode() == types.Text})
 	}

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -28,12 +28,14 @@ var (
 	)
 
 	Click = mcp.NewTool(ClickToolKey,
-		mcp.WithDescription("Perform click on a web page. Target element by ref (from snapshot), CSS selector, or accessible name/role. Priority: ref > selector > name."),
+		mcp.WithDescription("Perform click on a web page. Target element by ref (from snapshot), CSS selector, or accessible name/role. Priority: ref > selector > name. Supports right-click and double-click."),
 		mcp.WithString("element", mcp.Description("Human-readable element description used to obtain permission to interact with the element"), mcp.Required()),
 		mcp.WithString("ref", mcp.Description("Exact target element reference from the page snapshot.")),
 		mcp.WithString("selector", mcp.Description("CSS selector to find the element (e.g. '#submit-btn', '.my-class', 'input[name=email]').")),
 		mcp.WithString("name", mcp.Description("Accessible name to find the element by (case-insensitive substring match).")),
 		mcp.WithString("role", mcp.Description("ARIA role to filter by when using name-based targeting (e.g. button, link, textbox). Optional, used to disambiguate.")),
+		mcp.WithString("button", mcp.Description("Mouse button: left (default), right, or middle")),
+		mcp.WithNumber("click_count", mcp.Description("Number of clicks: 1 (default) or 2 for double-click")),
 	)
 
 	Hover = mcp.NewTool(HoverToolKey,
@@ -82,16 +84,44 @@ var (
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			// Invalidate snapshot before acting so Execute rebuilds a fresh one after.
 			rodCtx.InvalidateSnapshot()
-			page, element, ele, err := resolveSnapshotElement(rodCtx, request.GetArguments(), "click element")
+			args := request.GetArguments()
+			page, element, ele, err := resolveSnapshotElement(rodCtx, args, "click element")
 			if err != nil {
 				return toolErr("click element", err)
 			}
-			if err = element.Click(proto.InputMouseButtonLeft, 1); err != nil {
+
+			// Determine mouse button
+			btn := proto.InputMouseButtonLeft
+			btnName := getOptionalStringArg(args, "button")
+			switch btnName {
+			case "right":
+				btn = proto.InputMouseButtonRight
+			case "middle":
+				btn = proto.InputMouseButtonMiddle
+			case "", "left":
+				// default
+			default:
+				return toolErr("click element", fmt.Errorf("invalid button %q: must be left, right, or middle", btnName))
+			}
+
+			clickCount := int(getOptionalFloatArg(args, "click_count", 1))
+			if clickCount < 1 {
+				clickCount = 1
+			}
+
+			if err = element.Click(btn, clickCount); err != nil {
 				return toolErr("click element "+ele, err)
 			}
 
 			waitDOMStable(page)
-			return mcp.NewToolResultText(fmt.Sprintf("Click element %s successfully", ele)), nil
+			action := "Click"
+			if clickCount == 2 {
+				action = "Double-click"
+			}
+			if btnName == "right" {
+				action = "Right-click"
+			}
+			return mcp.NewToolResultText(fmt.Sprintf("%s element %s successfully", action, ele)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
 	}


### PR DESCRIPTION
## Summary
- **rod_click**: Add `button` param (left/right/middle) and `click_count` param (1/2) for right-click and double-click support
- **rod_press**: Add `modifiers` array param for keyboard combos like Ctrl+A, Ctrl+C, Shift+Tab

Closes #221, Closes #225

## Test plan
- [ ] `go test ./...` passes
- [ ] `cd e2e && go test -tags e2e -timeout 120s` passes
- [ ] `rod_click` with `button: "right"` triggers context menu
- [ ] `rod_click` with `click_count: 2` performs double-click
- [ ] `rod_press` with `key: "a", modifiers: ["control"]` performs select-all