### PR TITLE
feat: compound tools — navigate+snapshot, assert_element

### DIFF
--- a/tools/assert.go
+++ b/tools/assert.go
@@ -1,0 +1,142 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	AssertElementToolKey = "rod_assert_element"
+)
+
+var (
+	AssertElement = mcp.NewTool(AssertElementToolKey,
+		mcp.WithDescription("Assert element presence and optionally capture a screenshot. Returns element count and pass/fail status. On failure, includes page context for diagnosis."),
+		mcp.WithString("selector", mcp.Description("CSS selector to find elements")),
+		mcp.WithString("name", mcp.Description("Accessible name to search for (case-insensitive substring)")),
+		mcp.WithString("role", mcp.Description("ARIA role to filter by when using name-based targeting")),
+		mcp.WithBoolean("exists", mcp.Description("Whether element should exist (default: true)")),
+		mcp.WithNumber("min_count", mcp.Description("Minimum expected element count")),
+		mcp.WithNumber("timeout", mcp.Description("Max wait time in milliseconds (default: 5000)")),
+		mcp.WithBoolean("screenshot", mcp.Description("Include page screenshot in response (default: false)")),
+	)
+)
+
+var (
+	AssertElementHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("assert element", err)
+			}
+
+			args := request.GetArguments()
+			selector := getOptionalStringArg(args, "selector")
+			name := getOptionalStringArg(args, "name")
+			role := getOptionalStringArg(args, "role")
+			expectExists := getOptionalBoolArg(args, "exists", true)
+			minCount := int(getOptionalFloatArg(args, "min_count", 0))
+			timeout := getOptionalFloatArg(args, "timeout", 5000)
+			wantScreenshot := getOptionalBoolArg(args, "screenshot", false)
+
+			if selector == "" && name == "" {
+				return toolErr("assert element", fmt.Errorf("one of 'selector' or 'name' is required"))
+			}
+
+			var count int
+
+			if selector != "" {
+				// Poll for selector-based elements with timeout
+				deadline := time.After(time.Duration(timeout) * time.Millisecond)
+				ticker := time.NewTicker(200 * time.Millisecond)
+				defer ticker.Stop()
+
+				for {
+					elements, _ := page.Elements(selector)
+					count = len(elements)
+					if expectExists && count > 0 && count >= minCount {
+						break
+					}
+					if !expectExists && count == 0 {
+						break
+					}
+					select {
+					case <-deadline:
+						goto done
+					case <-ticker.C:
+						continue
+					}
+				}
+			} else {
+				// Name-based via snapshot
+				snapshot, snapErr := rodCtx.EnsureSnapshot()
+				if snapErr != nil {
+					return toolErr("assert element", snapErr)
+				}
+				matches := snapshot.FindByNameRole(name, role)
+				count = len(matches)
+			}
+		done:
+
+			// Build result
+			passed := true
+			var failReason string
+			target := selector
+			if target == "" {
+				target = fmt.Sprintf("name=%q", name)
+				if role != "" {
+					target += fmt.Sprintf(" role=%q", role)
+				}
+			}
+
+			if expectExists && count == 0 {
+				passed = false
+				failReason = fmt.Sprintf("expected %s to exist, but not found", target)
+			} else if !expectExists && count > 0 {
+				passed = false
+				failReason = fmt.Sprintf("expected %s to not exist, but found %d", target, count)
+			} else if minCount > 0 && count < minCount {
+				passed = false
+				failReason = fmt.Sprintf("expected at least %d elements matching %s, found %d", minCount, target, count)
+			}
+
+			result := map[string]interface{}{
+				"passed": passed,
+				"count":  count,
+				"target": target,
+			}
+			if !passed {
+				result["error"] = failReason
+				info, infoErr := page.Info()
+				if infoErr == nil {
+					result["page_url"] = info.URL
+					result["page_title"] = info.Title
+				}
+			}
+
+			out, _ := json.MarshalIndent(result, "", "  ")
+
+			if wantScreenshot {
+				bin, shotErr := page.Screenshot(false, &proto.PageCaptureScreenshot{
+					Format: proto.PageCaptureScreenshotFormatPng,
+				})
+				if shotErr == nil {
+					encoded := base64.StdEncoding.EncodeToString(bin)
+					return mcp.NewToolResultImage(string(out), encoded, "image/png"), nil
+				}
+			}
+
+			return mcp.NewToolResultText(string(out)), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	"github.com/charmbracelet/log"
 	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -22,8 +24,10 @@ const (
 
 var (
 	Navigation = mcp.NewTool(NavigationToolKey,
-		mcp.WithDescription("Navigate to a URL"),
+		mcp.WithDescription("Navigate to a URL. Optionally include an accessibility snapshot or screenshot in the response to save round trips."),
 		mcp.WithString("url", mcp.Description("URL to navigate to"), mcp.Required()),
+		mcp.WithBoolean("snapshot", mcp.Description("Include accessibility snapshot in response (default: false). Only available in text mode.")),
+		mcp.WithBoolean("screenshot", mcp.Description("Include screenshot in response (default: false)")),
 	)
 	GoBack = mcp.NewTool(GoBackToolKey,
 		mcp.WithDescription("Go back in the browser history, go back to the previous page"),
@@ -63,13 +67,17 @@ var (
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			// Navigation changes the page; invalidate so Execute rebuilds the snapshot.
 			rodCtx.InvalidateSnapshot()
-			url, err := getStringArg(request.GetArguments(), "url")
+			args := request.GetArguments()
+			url, err := getStringArg(args, "url")
 			if err != nil {
 				return toolErr("navigate", err)
 			}
 			if !utils.IsHttp(url) {
 				return nil, toolError("navigate", fmt.Errorf("invalid URL: %s", url))
 			}
+
+			wantSnapshot := getOptionalBoolArg(args, "snapshot", false)
+			wantScreenshot := getOptionalBoolArg(args, "screenshot", false)
 
 			page, err := rodCtx.EnsurePage()
 			if err != nil {
@@ -88,8 +96,37 @@ var (
 				return toolErr("navigate to "+url, err)
 			}
 			waitDOMStable(page)
-			return mcp.NewToolResultText(fmt.Sprintf("Navigated to %s", url)), nil
+
+			result := fmt.Sprintf("Navigated to %s", url)
+
+			// Append inline snapshot if requested
+			if wantSnapshot && rodCtx.CurrentMode() == types.Text {
+				snapshot, snapErr := rodCtx.BuildSnapshot()
+				if snapErr != nil {
+					log.Warnf("navigate snapshot: %s", snapErr)
+				} else {
+					result += "\n\n" + snapshot
+				}
+			}
+
+			// Return screenshot inline if requested
+			if wantScreenshot {
+				bin, shotErr := page.Screenshot(false, &proto.PageCaptureScreenshot{
+					Format: proto.PageCaptureScreenshotFormatPng,
+				})
+				if shotErr != nil {
+					log.Warnf("navigate screenshot: %s", shotErr)
+				} else {
+					encoded := base64.StdEncoding.EncodeToString(bin)
+					return mcp.NewToolResultImage(result, encoded, "image/png"), nil
+				}
+			}
+
+			return mcp.NewToolResultText(result), nil
 		}
+		// In text mode, auto-append snapshot (preserving existing behavior).
+		// The explicit snapshot=true param adds it earlier in the response for
+		// agents that want it bundled with navigation in non-text mode.
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: rodCtx.CurrentMode() == types.Text})
 	}
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -58,6 +58,7 @@ var (
 		A11yAudit,
 		PageInfo,
 		PageStatus,
+		AssertElement,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		ConfigureToolKey:       ConfigureHandler,
@@ -97,6 +98,7 @@ var (
 		A11yAuditToolKey:       A11yAuditHandler,
 		PageInfoToolKey:        PageInfoHandler,
 		PageStatusToolKey:      PageStatusHandler,
+		AssertElementToolKey:   AssertElementHandler,
 	}
 )
 


### PR DESCRIPTION
## Summary
- **rod_navigate**: Add `snapshot` and `screenshot` optional params to bundle page capture with navigation, saving 2 round trips per page visit
- **rod_assert_element**: New tool for element presence checks with optional screenshot evidence and failure context (page URL/title)
- **rod_wait_for**: Already supports `text` param — #203 closed as already covered

Closes #200, Closes #203, Closes #202

## Test plan
- [ ] `go test ./...` passes
- [ ] `cd e2e && go test -tags e2e -timeout 120s` passes
- [ ] `rod_navigate` with `snapshot: true` returns inline snapshot
- [ ] `rod_assert_element` returns pass/fail with count
- [ ] Assert failure includes page_url and page_title context