### PR TITLE
feat: batch action execution and screenshot comparison

### DIFF
--- a/tools/batch.go
+++ b/tools/batch.go
@@ -1,0 +1,138 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	BatchToolKey = "rod_batch"
+)
+
+// batchAllowedHandlers maps tool names to their handler factories for batch execution.
+// Only side-effect tools are allowed; navigation and read-only tools are excluded.
+// Defined as a function to break the initialization cycle with CommonToolHandlers.
+var batchAllowedHandlers = map[string]ToolHandler{
+	FillToolKey:     FillHandler,
+	ClickToolKey:    ClickHandler,
+	HoverToolKey:    HoverHandler,
+	SelectorToolKey: SelectorHandler,
+	PressKeyToolKey: PressKeyHandler,
+	ScrollToolKey:   ScrollHandler,
+	TypeToolKey:     TypeHandler,
+}
+
+var (
+	Batch = mcp.NewTool(BatchToolKey,
+		mcp.WithDescription("Execute multiple actions in a single call. Reduces round trips for form fills and multi-step interactions. Stops on first error. Only side-effect tools allowed: rod_fill, rod_click, rod_hover, rod_selector, rod_press, rod_scroll, rod_type."),
+		mcp.WithArray("actions",
+			mcp.Description("Array of actions to execute sequentially. Each action has 'tool' (tool name) and 'args' (tool arguments)."),
+			mcp.Items(map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"tool": map[string]interface{}{"type": "string"},
+					"args": map[string]interface{}{"type": "object"},
+				},
+				"required": []string{"tool", "args"},
+			}),
+			mcp.Required(),
+		),
+	)
+)
+
+var (
+	BatchHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := request.GetArguments()
+
+			actionsRaw, ok := args["actions"]
+			if !ok {
+				return toolErr("batch", fmt.Errorf("missing required argument: actions"))
+			}
+			actionsArr, ok := actionsRaw.([]interface{})
+			if !ok || len(actionsArr) == 0 {
+				return toolErr("batch", fmt.Errorf("actions must be a non-empty array"))
+			}
+
+			// Invalidate snapshot once at the start
+			rodCtx.InvalidateSnapshot()
+
+			type actionResult struct {
+				Tool    string `json:"tool"`
+				Success bool   `json:"success"`
+				Message string `json:"message,omitempty"`
+				Error   string `json:"error,omitempty"`
+			}
+
+			var results []actionResult
+
+			for i, actionRaw := range actionsArr {
+				actionMap, ok := actionRaw.(map[string]interface{})
+				if !ok {
+					return toolErr("batch", fmt.Errorf("actions[%d] must be an object", i))
+				}
+				toolName, ok := actionMap["tool"].(string)
+				if !ok || toolName == "" {
+					return toolErr("batch", fmt.Errorf("actions[%d].tool must be a non-empty string", i))
+				}
+				toolArgs, _ := actionMap["args"].(map[string]interface{})
+				if toolArgs == nil {
+					toolArgs = map[string]interface{}{}
+				}
+
+				handlerFactory, allowed := batchAllowedHandlers[toolName]
+				if !allowed {
+					return toolErr("batch", fmt.Errorf("actions[%d]: tool %q is not allowed in batch. Allowed: rod_fill, rod_click, rod_hover, rod_selector, rod_press, rod_scroll, rod_type", i, toolName))
+				}
+
+				// Build a synthetic MCP request
+				innerReq := mcp.CallToolRequest{}
+				innerReq.Params.Name = toolName
+				innerReq.Params.Arguments = toolArgs
+
+				// Execute the inner handler directly (bypass Execute wrapper)
+				innerHandler := handlerFactory(rodCtx)
+				result, err := innerHandler(ctx, innerReq)
+				if err != nil {
+					results = append(results, actionResult{
+						Tool:    toolName,
+						Success: false,
+						Error:   err.Error(),
+					})
+					// Stop on first error
+					break
+				}
+
+				// Extract text from result
+				msg := ""
+				if result != nil && len(result.Content) > 0 {
+					for _, c := range result.Content {
+						if tc, ok := c.(mcp.TextContent); ok {
+							msg = tc.Text
+							break
+						}
+					}
+				}
+				results = append(results, actionResult{
+					Tool:    toolName,
+					Success: true,
+					Message: msg,
+				})
+			}
+
+			out, _ := json.MarshalIndent(map[string]interface{}{
+				"total":     len(actionsArr),
+				"completed": len(results),
+				"results":   results,
+			}, "", "  ")
+			return mcp.NewToolResultText(string(out)), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
+	}
+)

--- a/tools/compare.go
+++ b/tools/compare.go
@@ -1,0 +1,178 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"math"
+	"os"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	CompareScreenshotsToolKey = "rod_compare_screenshots"
+
+	defaultSimilarityThreshold = 0.95
+)
+
+var (
+	CompareScreenshots = mcp.NewTool(CompareScreenshotsToolKey,
+		mcp.WithDescription("Compare two screenshot images pixel-by-pixel. Returns similarity score, pass/fail status, and optional diff image. Useful for visual regression testing."),
+		mcp.WithString("baseline", mcp.Description("Path to the baseline image (PNG)"), mcp.Required()),
+		mcp.WithString("current", mcp.Description("Path to the current image (PNG)"), mcp.Required()),
+		mcp.WithNumber("threshold", mcp.Description("Similarity threshold (0-1) for pass/fail (default: 0.95)")),
+		mcp.WithBoolean("save_diff", mcp.Description("Save diff image to output directory (default: false)")),
+	)
+)
+
+var (
+	CompareScreenshotsHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := request.GetArguments()
+			baselinePath, err := getStringArg(args, "baseline")
+			if err != nil {
+				return toolErr("compare screenshots", err)
+			}
+			currentPath, err := getStringArg(args, "current")
+			if err != nil {
+				return toolErr("compare screenshots", err)
+			}
+			threshold := getOptionalFloatArg(args, "threshold", defaultSimilarityThreshold)
+			saveDiff := getOptionalBoolArg(args, "save_diff", false)
+
+			// Load images
+			baselineImg, err := loadPNG(baselinePath)
+			if err != nil {
+				return toolErr("load baseline", err)
+			}
+			currentImg, err := loadPNG(currentPath)
+			if err != nil {
+				return toolErr("load current", err)
+			}
+
+			// Compare
+			baseBounds := baselineImg.Bounds()
+			currBounds := currentImg.Bounds()
+
+			if baseBounds.Dx() != currBounds.Dx() || baseBounds.Dy() != currBounds.Dy() {
+				return toolErr("compare screenshots", fmt.Errorf(
+					"image dimensions differ: baseline %dx%d, current %dx%d",
+					baseBounds.Dx(), baseBounds.Dy(), currBounds.Dx(), currBounds.Dy(),
+				))
+			}
+
+			width := baseBounds.Dx()
+			height := baseBounds.Dy()
+			totalPixels := width * height
+			var diffPixels int
+
+			// Create diff image
+			diffImg := image.NewRGBA(baseBounds)
+
+			for y := baseBounds.Min.Y; y < baseBounds.Max.Y; y++ {
+				for x := baseBounds.Min.X; x < baseBounds.Max.X; x++ {
+					br, bg, bb, ba := baselineImg.At(x, y).RGBA()
+					cr, cg, cb, ca := currentImg.At(x, y).RGBA()
+
+					if pixelsDiffer(br, bg, bb, ba, cr, cg, cb, ca) {
+						diffPixels++
+						diffImg.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 180})
+					} else {
+						// Dim the matching pixels
+						r, g, b, _ := baselineImg.At(x, y).RGBA()
+						diffImg.Set(x, y, color.RGBA{
+							R: uint8(r >> 9), // half brightness
+							G: uint8(g >> 9),
+							B: uint8(b >> 9),
+							A: 255,
+						})
+					}
+				}
+			}
+
+			similarity := 1.0
+			if totalPixels > 0 {
+				similarity = 1.0 - float64(diffPixels)/float64(totalPixels)
+			}
+			passed := similarity >= threshold
+
+			result := map[string]interface{}{
+				"similarity":   math.Round(similarity*10000) / 10000,
+				"passed":       passed,
+				"diff_pixels":  diffPixels,
+				"total_pixels": totalPixels,
+				"threshold":    threshold,
+			}
+
+			if saveDiff {
+				diffPath, saveErr := saveDiffImage(rodCtx.Config(), diffImg)
+				if saveErr != nil {
+					return toolErr("save diff image", saveErr)
+				}
+				result["diff_image_path"] = diffPath
+			}
+
+			out, _ := json.MarshalIndent(result, "", "  ")
+			return mcp.NewToolResultText(string(out)), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+	}
+)
+
+// loadPNG reads a PNG image from disk.
+func loadPNG(path string) (image.Image, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	img, err := png.Decode(f)
+	if err != nil {
+		// Try generic decode as fallback (handles other formats registered)
+		_, seekErr := f.Seek(0, 0)
+		if seekErr != nil {
+			return nil, fmt.Errorf("cannot decode %s as PNG: %w", path, err)
+		}
+		img, _, decodeErr := image.Decode(f)
+		if decodeErr != nil {
+			return nil, fmt.Errorf("cannot decode %s: %w", path, err)
+		}
+		return img, nil
+	}
+	return img, nil
+}
+
+// pixelsDiffer returns true if two pixels differ beyond a small tolerance.
+// RGBA values are in the 0-65535 range from Color.RGBA().
+func pixelsDiffer(r1, g1, b1, a1, r2, g2, b2, a2 uint32) bool {
+	const tolerance = 1280 // ~2% of 65535
+	return absDiff(r1, r2) > tolerance ||
+		absDiff(g1, g2) > tolerance ||
+		absDiff(b1, b2) > tolerance ||
+		absDiff(a1, a2) > tolerance
+}
+
+func absDiff(a, b uint32) uint32 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}
+
+// saveDiffImage encodes and saves the diff image to the output directory.
+func saveDiffImage(cfg types.Config, img *image.RGBA) (string, error) {
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return "", fmt.Errorf("encode diff image: %w", err)
+	}
+	return types.SaveOutput(cfg, buf.Bytes(), "diff", "png")
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -64,6 +64,8 @@ var (
 		Race,
 		Geolocation,
 		BasicAuth,
+		Batch,
+		CompareScreenshots,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		ConfigureToolKey:       ConfigureHandler,
@@ -107,8 +109,10 @@ var (
 		FrameListToolKey:       FrameListHandler,
 		DownloadToolKey:        DownloadHandler,
 		RaceToolKey:            RaceHandler,
-		GeolocationToolKey:     GeolocationHandler,
-		BasicAuthToolKey:       BasicAuthHandler,
+		GeolocationToolKey:          GeolocationHandler,
+		BasicAuthToolKey:            BasicAuthHandler,
+		BatchToolKey:                BatchHandler,
+		CompareScreenshotsToolKey:   CompareScreenshotsHandler,
 	}
 )
 


### PR DESCRIPTION
## Summary
- Add `rod_batch` tool to execute multiple side-effect actions in one MCP call (#201)
- Add `rod_compare_screenshots` tool for pixel-by-pixel visual diff with similarity scoring (#205)

## Test plan
- [ ] `go build -o rod-mcp` — builds clean
- [ ] `go test ./...` — all tests pass
- [ ] Manual: batch fill email + password + click submit in one call
- [ ] Manual: compare two screenshots and verify similarity score

Closes #201, closes #205