### PR TITLE
feat: login flow and cookie persistence

### DIFF
--- a/tools/cookies.go
+++ b/tools/cookies.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
+	"github.com/charmbracelet/log"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -19,7 +24,7 @@ const (
 var (
 	Cookies = mcp.NewTool(CookiesToolKey,
 		mcp.WithDescription("Manage browser cookies via CDP. Get, set, delete, or clear cookies including httpOnly cookies not visible to document.cookie."),
-		mcp.WithString("action", mcp.Description("Action to perform"), mcp.Required(), mcp.Enum("get", "set", "delete", "clear")),
+		mcp.WithString("action", mcp.Description("Action to perform"), mcp.Required(), mcp.Enum("get", "set", "delete", "clear", "save", "restore")),
 		mcp.WithString("url", mcp.Description("URL to get cookies for (get) or associate with (set/delete). Defaults to current page URL.")),
 		mcp.WithString("name", mcp.Description("Cookie name (required for set and delete)")),
 		mcp.WithString("value", mcp.Description("Cookie value (required for set)")),
@@ -28,6 +33,7 @@ var (
 		mcp.WithBoolean("secure", mcp.Description("Secure flag (optional for set)")),
 		mcp.WithBoolean("httpOnly", mcp.Description("HttpOnly flag (optional for set)")),
 		mcp.WithString("sameSite", mcp.Description("SameSite attribute (optional for set)"), mcp.Enum("Strict", "Lax", "None")),
+		mcp.WithString("file_path", mcp.Description("File path for save/restore actions. Must be within the output directory.")),
 	)
 )
 
@@ -153,10 +159,101 @@ var (
 				}
 				return mcp.NewToolResultText("All cookies cleared"), nil
 
-			default:
-				return nil, fmt.Errorf("invalid action %q: must be get, set, delete, or clear", action)
+			case "save":
+				savePath, err := getCookieFilePath(rodCtx, args)
+				if err != nil {
+					return toolErr("save cookies", err)
+				}
+
+				resp, err := proto.NetworkGetAllCookies{}.Call(page)
+				if err != nil {
+					return toolErr("save cookies", err)
+				}
+				data, err := json.MarshalIndent(resp.Cookies, "", "  ")
+				if err != nil {
+					return toolErr("save cookies", err)
+				}
+				if err := os.WriteFile(savePath, data, 0o644); err != nil {
+					return toolErr("save cookies", fmt.Errorf("write %s: %w", savePath, err))
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("Saved %d cookies to %s", len(resp.Cookies), savePath)), nil
+
+			case "restore":
+				restorePath, err := getCookieFilePath(rodCtx, args)
+				if err != nil {
+					return toolErr("restore cookies", err)
+				}
+
+				data, err := os.ReadFile(restorePath)
+				if err != nil {
+					return toolErr("restore cookies", fmt.Errorf("read %s: %w", restorePath, err))
+				}
+				var cookies []*proto.NetworkCookie
+				if err := json.Unmarshal(data, &cookies); err != nil {
+					return toolErr("restore cookies", fmt.Errorf("parse %s: %w", restorePath, err))
+				}
+
+				now := proto.TimeSinceEpoch(time.Now().Unix())
+				var restored, skipped int
+				for _, c := range cookies {
+					// Skip expired cookies
+					if c.Expires > 0 && c.Expires < now {
+						log.Debugf("cookie %q expired, skipping", c.Name)
+						skipped++
+						continue
+					}
+					setCookie := proto.NetworkSetCookie{
+						Name:     c.Name,
+						Value:    c.Value,
+						Domain:   c.Domain,
+						Path:     c.Path,
+						Secure:   c.Secure,
+						HTTPOnly: c.HTTPOnly,
+						SameSite: c.SameSite,
+					}
+					if c.Expires > 0 {
+						setCookie.Expires = c.Expires
+					}
+					if _, err := setCookie.Call(page); err != nil {
+						log.Warnf("failed to restore cookie %q: %s", c.Name, err)
+						continue
+					}
+					restored++
+				}
+				msg := fmt.Sprintf("Restored %d cookies from %s", restored, restorePath)
+				if skipped > 0 {
+					msg += fmt.Sprintf(" (%d expired cookies skipped)", skipped)
+				}
+				return mcp.NewToolResultText(msg), nil
+
+					default:
+				return nil, fmt.Errorf("invalid action %q: must be get, set, delete, clear, save, or restore", action)
 			}
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
 )
+
+// getCookieFilePath resolves and validates the file path for cookie save/restore.
+// Restricts paths to be within the output directory to prevent path traversal.
+func getCookieFilePath(rodCtx *types.Context, args map[string]interface{}) (string, error) {
+	fp := getOptionalStringArg(args, "file_path")
+	if fp == "" {
+		return "", fmt.Errorf("file_path is required for save/restore actions")
+	}
+
+	outDir, err := types.ResolveOutputDir(rodCtx.Config())
+	if err != nil {
+		return "", err
+	}
+
+	// Resolve relative to output directory
+	if !filepath.IsAbs(fp) {
+		fp = filepath.Join(outDir, fp)
+	}
+	cleaned := filepath.Clean(fp)
+	if !strings.HasPrefix(cleaned, filepath.Clean(outDir)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("file_path must be within output directory %s", outDir)
+	}
+	return cleaned, nil
+}

--- a/tools/login.go
+++ b/tools/login.go
@@ -1,0 +1,216 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+const (
+	LoginToolKey = "rod_login"
+
+	defaultLoginTimeoutMs = 15000.0
+)
+
+var (
+	Login = mcp.NewTool(LoginToolKey,
+		mcp.WithDescription("Execute a login flow in one call: navigate to URL, fill credentials, submit, and verify success. Replaces 5-6 individual MCP calls."),
+		mcp.WithString("url", mcp.Description("Login page URL"), mcp.Required()),
+		mcp.WithString("username", mcp.Description("Username or email to fill"), mcp.Required()),
+		mcp.WithString("password", mcp.Description("Password to fill"), mcp.Required()),
+		mcp.WithString("username_selector", mcp.Description("CSS selector for username/email field (default: input[type=email], input[name=email], input[name=username])")),
+		mcp.WithString("password_selector", mcp.Description("CSS selector for password field (default: input[type=password])")),
+		mcp.WithString("submit_selector", mcp.Description("CSS selector for submit button (default: button[type=submit])")),
+		mcp.WithString("success_selector", mcp.Description("CSS selector that indicates login succeeded (waits for it to appear)")),
+		mcp.WithString("success_url_contains", mcp.Description("Substring to match in URL after login to verify success")),
+		mcp.WithNumber("timeout", mcp.Description("Max wait time for success verification in milliseconds (default: 15000)")),
+	)
+)
+
+// defaultUsernameSelectors are tried in order when no username_selector is provided.
+var defaultUsernameSelectors = []string{
+	"input[type=email]",
+	"input[name=email]",
+	"input[name=username]",
+	"input[name=login]",
+	"input[id=email]",
+	"input[id=username]",
+}
+
+var (
+	LoginHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
+		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			rodCtx.InvalidateSnapshot()
+
+			args := request.GetArguments()
+			loginURL, err := getStringArg(args, "url")
+			if err != nil {
+				return toolErr("login", err)
+			}
+			username, err := getStringArg(args, "username")
+			if err != nil {
+				return toolErr("login", err)
+			}
+			password, err := getStringArg(args, "password")
+			if err != nil {
+				return toolErr("login", err)
+			}
+
+			userSelector := getOptionalStringArg(args, "username_selector")
+			passSelector := getOptionalStringArg(args, "password_selector")
+			submitSelector := getOptionalStringArg(args, "submit_selector")
+			successSelector := getOptionalStringArg(args, "success_selector")
+			successURL := getOptionalStringArg(args, "success_url_contains")
+			timeout := getOptionalFloatArg(args, "timeout", defaultLoginTimeoutMs)
+
+			if passSelector == "" {
+				passSelector = "input[type=password]"
+			}
+			if submitSelector == "" {
+				submitSelector = "button[type=submit]"
+			}
+
+			// Step 1: Navigate to login page
+			page, err := rodCtx.ControlledPage()
+			if err != nil {
+				return toolErr("login navigate", err)
+			}
+			if err := page.Navigate(loginURL); err != nil {
+				return toolErr("login navigate", err)
+			}
+			if err := page.WaitLoad(); err != nil {
+				return toolErr("login wait load", err)
+			}
+			waitDOMStable(page)
+
+			// Step 2: Find and fill username field
+			if userSelector != "" {
+				el, err := page.Element(userSelector)
+				if err != nil {
+					return toolErr("login find username", fmt.Errorf("selector %q: %w", userSelector, err))
+				}
+				if err := el.SelectAllText(); err != nil {
+					return toolErr("login clear username", err)
+				}
+				if err := el.Input(username); err != nil {
+					return toolErr("login fill username", err)
+				}
+			} else {
+				// Try default selectors
+				filled := false
+				for _, sel := range defaultUsernameSelectors {
+					el, err := page.Element(sel)
+					if err == nil {
+						_ = el.SelectAllText()
+						if inputErr := el.Input(username); inputErr == nil {
+							filled = true
+							break
+						}
+					}
+				}
+				if !filled {
+					return toolErr("login fill username", fmt.Errorf("could not find username field; provide username_selector"))
+				}
+			}
+
+			// Step 3: Fill password
+			passEl, err := page.Element(passSelector)
+			if err != nil {
+				return toolErr("login find password", fmt.Errorf("selector %q: %w", passSelector, err))
+			}
+			if err := passEl.SelectAllText(); err != nil {
+				return toolErr("login clear password", err)
+			}
+			if err := passEl.Input(password); err != nil {
+				return toolErr("login fill password", err)
+			}
+
+			// Step 4: Submit
+			submitEl, err := page.Element(submitSelector)
+			if err != nil {
+				return toolErr("login find submit", fmt.Errorf("selector %q: %w", submitSelector, err))
+			}
+			if err := submitEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
+				return toolErr("login click submit", err)
+			}
+
+			// Step 5: Verify success
+			timeoutDur := time.Duration(timeout) * time.Millisecond
+			deadline := time.After(timeoutDur)
+			ticker := time.NewTicker(300 * time.Millisecond)
+			defer ticker.Stop()
+
+			verified := false
+			if successSelector == "" && successURL == "" {
+				// No explicit success check — wait for navigation to settle
+				if navErr := page.WaitLoad(); navErr == nil {
+					waitDOMStable(page)
+				}
+				verified = true
+			} else {
+				for {
+					if successSelector != "" {
+						if _, err := page.Element(successSelector); err == nil {
+							verified = true
+							break
+						}
+					}
+					if successURL != "" {
+						info, err := page.Info()
+						if err == nil {
+							if strings.Contains(info.URL, successURL) {
+								verified = true
+								break
+							}
+						}
+					}
+					select {
+					case <-deadline:
+						goto done
+					case <-ticker.C:
+						continue
+					}
+				}
+			}
+		done:
+
+			info, _ := page.Info()
+			currentURL := ""
+			title := ""
+			if info != nil {
+				currentURL = info.URL
+				title = info.Title
+			}
+
+			// Count cookies set
+			resp, _ := proto.NetworkGetCookies{}.Call(page)
+			cookieCount := 0
+			if resp != nil {
+				cookieCount = len(resp.Cookies)
+			}
+
+			result := map[string]interface{}{
+				"success":     verified,
+				"url":         currentURL,
+				"title":       title,
+				"cookies_set": cookieCount,
+			}
+			if !verified {
+				result["error"] = fmt.Sprintf("login verification timed out after %dms", int(timeout))
+			}
+
+			out, _ := json.MarshalIndent(result, "", "  ")
+			return mcp.NewToolResultText(string(out)), nil
+		}
+		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
+	}
+)
+

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -66,6 +66,7 @@ var (
 		BasicAuth,
 		Batch,
 		CompareScreenshots,
+		Login,
 	}
 	CommonToolHandlers = map[string]ToolHandler{
 		ConfigureToolKey:       ConfigureHandler,
@@ -113,6 +114,7 @@ var (
 		BasicAuthToolKey:            BasicAuthHandler,
 		BatchToolKey:                BatchHandler,
 		CompareScreenshotsToolKey:   CompareScreenshotsHandler,
+		LoginToolKey:                LoginHandler,
 	}
 )
 


### PR DESCRIPTION
## Summary
- Add `rod_login` tool for one-call login flows: navigate → fill → submit → verify (#207)
- Extend `rod_cookies` with `save`/`restore` actions for cookie persistence across restarts (#208)

## Test plan
- [ ] `go build -o rod-mcp` — builds clean
- [ ] `go test ./...` — all tests pass
- [ ] Manual: use rod_login to log into a test app with custom selectors
- [ ] Manual: save cookies, restart server, restore cookies and verify session

Closes #207, closes #208