### PR TITLE
fix: snapshot ref resolution, React fill state sync, and modal login

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -76,21 +76,20 @@ var MyTool = mcp.NewTool("rod_my_tool",
 
 var MyToolHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
     handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-        // 1. Invalidate snapshot if this tool mutates the DOM
-        rodCtx.InvalidateSnapshot()
-
-        // 2. Get the controlled page
+        // 1. Get the controlled page
         page, err := rodCtx.ControlledPage()
         if err != nil {
             return toolErr("my tool", err)
         }
 
-        // 3. Do work...
+        // 2. Do work (the previous snapshot is still available for ref resolution)...
 
-        // 4. Return result
+        // 3. Return result
         return mcp.NewToolResultText("result"), nil
     }
-    // WithSnapshot: true rebuilds and appends ARIA snapshot after execution
+    // Execute invalidates the snapshot after the handler returns and, when
+    // WithSnapshot: true, rebuilds and appends a fresh ARIA snapshot.
+    // Do NOT call InvalidateSnapshot() inside handlers — Execute handles it.
     return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
 }
 ```
@@ -102,7 +101,7 @@ var MyToolHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 
 ### Snapshot Lifecycle
 
-DOM-mutating tools must call `rodCtx.InvalidateSnapshot()` at the start. The `Execute()` wrapper with `WithSnapshot: true` rebuilds and appends a fresh ARIA snapshot after the handler completes. This enables ref-based element targeting in subsequent calls.
+The `Execute()` wrapper automatically invalidates the snapshot after every handler returns, then rebuilds and appends a fresh ARIA snapshot when `WithSnapshot: true`. Handlers must **not** call `InvalidateSnapshot()` themselves — the previous snapshot remains available during handler execution for ref-based element resolution.
 
 ### Element Resolution
 
@@ -178,7 +177,7 @@ docs: description of documentation changes
 ## Common Mistakes
 
 1. **Passing element as JS function parameter** — rod's `Eval()` binds the element as `this`, not as a function argument
-2. **Forgetting `InvalidateSnapshot()`** — DOM-mutating tools must invalidate before executing
+2. **Calling `InvalidateSnapshot()` inside handlers** — `Execute()` handles invalidation automatically after the handler returns. Calling it inside the handler destroys the snapshot before ref-based resolution can use it
 3. **Using `WithSnapshot: false` on tools that need ref continuity** — subsequent ref-based operations will fail with "no snapshot available"
 4. **Not calling `waitDOMStable(page)`** — after DOM mutations, wait for stability before reading state
 5. **Importing `proto` without using CDP methods** — only import `github.com/go-rod/rod/lib/proto` when using Chrome DevTools Protocol directly

--- a/tools/drag.go
+++ b/tools/drag.go
@@ -63,8 +63,6 @@ func resolvePosition(page *rod.Page, args map[string]interface{}, selectorKey, x
 var (
 	DragHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Drag modifies DOM layout; invalidate so Execute rebuilds the snapshot.
-			rodCtx.InvalidateSnapshot()
 			page, err := rodCtx.ControlledPage()
 			if err != nil {
 				return toolErr("drag", err)

--- a/tools/fill.go
+++ b/tools/fill.go
@@ -87,8 +87,6 @@ func smartFillElement(element *rod.Element, value string) (*smartFillResult, err
 
 var FillFormHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		rodCtx.InvalidateSnapshot()
-
 		page, err := rodCtx.ControlledPage()
 		if err != nil {
 			return toolErr("fill form", err)

--- a/tools/input.go
+++ b/tools/input.go
@@ -43,8 +43,6 @@ var (
 var (
 	PressKeyHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Key presses may modify DOM; invalidate so Execute rebuilds the snapshot.
-			rodCtx.InvalidateSnapshot()
 			page, err := rodCtx.ControlledPage()
 			if err != nil {
 				return toolErr("press key", err)
@@ -105,8 +103,6 @@ var (
 
 	TypeHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Typing modifies DOM; invalidate so Execute rebuilds the snapshot.
-			rodCtx.InvalidateSnapshot()
 			page, err := rodCtx.ControlledPage()
 			if err != nil {
 				return toolErr("type text", err)

--- a/tools/login.go
+++ b/tools/login.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/aliwatters/rod-mcp/types"
+	"github.com/aliwatters/rod-mcp/types/js"
 )
 
 const (
@@ -22,8 +24,8 @@ const (
 
 var (
 	Login = mcp.NewTool(LoginToolKey,
-		mcp.WithDescription("Execute a login flow in one call: navigate to URL, fill credentials, submit, and verify success. Replaces 5-6 individual MCP calls."),
-		mcp.WithString("url", mcp.Description("Login page URL"), mcp.Required()),
+		mcp.WithDescription("Execute a login flow in one call: navigate to URL, fill credentials, submit, and verify success. Supports both dedicated login pages and modal dialogs triggered by a button click. Replaces 5-6 individual MCP calls."),
+		mcp.WithString("url", mcp.Description("Login page URL (or base page URL when using trigger_selector)"), mcp.Required()),
 		mcp.WithString("username", mcp.Description("Username or email to fill"), mcp.Required()),
 		mcp.WithString("password", mcp.Description("Password to fill"), mcp.Required()),
 		mcp.WithString("username_selector", mcp.Description("CSS selector for username/email field (default: input[type=email], input[name=email], input[name=username])")),
@@ -32,6 +34,8 @@ var (
 		mcp.WithString("success_selector", mcp.Description("CSS selector that indicates login succeeded (waits for it to appear)")),
 		mcp.WithString("success_url_contains", mcp.Description("Substring to match in URL after login to verify success")),
 		mcp.WithNumber("timeout", mcp.Description("Max wait time for success verification in milliseconds (default: 15000)")),
+		mcp.WithString("trigger_selector", mcp.Description("CSS selector for a button/link that opens the login form (for modal-based logins). Navigate to url first, then click this element before filling credentials.")),
+		mcp.WithString("form_container", mcp.Description("CSS selector for the login form container to wait for after clicking trigger (default: [role=dialog]). Only used with trigger_selector.")),
 	)
 )
 
@@ -45,11 +49,28 @@ var defaultUsernameSelectors = []string{
 	"input[id=username]",
 }
 
+// loginSmartFill fills an input using the embedded smart fill JS for React support.
+func loginSmartFill(element *rod.Element, value string) error {
+	obj, err := element.Eval(js.SmartFillJS, value)
+	if err != nil {
+		return fmt.Errorf("smart fill failed: %w", err)
+	}
+	var result struct {
+		Success bool   `json:"success"`
+		Value   string `json:"value"`
+	}
+	if parseErr := json.Unmarshal([]byte(obj.Value.Str()), &result); parseErr != nil {
+		return nil // can't parse but fill was attempted
+	}
+	if !result.Success {
+		return fmt.Errorf("fill produced %q instead of expected value", result.Value)
+	}
+	return nil
+}
+
 var (
 	LoginHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			rodCtx.InvalidateSnapshot()
-
 			args := request.GetArguments()
 			loginURL, err := getStringArg(args, "url")
 			if err != nil {
@@ -70,12 +91,17 @@ var (
 			successSelector := getOptionalStringArg(args, "success_selector")
 			successURL := getOptionalStringArg(args, "success_url_contains")
 			timeout := getOptionalFloatArg(args, "timeout", defaultLoginTimeoutMs)
+			triggerSelector := getOptionalStringArg(args, "trigger_selector")
+			formContainer := getOptionalStringArg(args, "form_container")
 
 			if passSelector == "" {
 				passSelector = "input[type=password]"
 			}
 			if submitSelector == "" {
 				submitSelector = "button[type=submit]"
+			}
+			if formContainer == "" {
+				formContainer = "[role=dialog]"
 			}
 
 			// Step 1: Navigate to login page
@@ -91,55 +117,117 @@ var (
 			}
 			waitDOMStable(page)
 
-			// Step 2: Find and fill username field
-			if userSelector != "" {
-				el, err := page.Element(userSelector)
+			// Step 1b: If trigger_selector is set, click it to open the login form
+			if triggerSelector != "" {
+				triggerEl, err := page.Element(triggerSelector)
 				if err != nil {
-					return toolErr("login find username", fmt.Errorf("selector %q: %w", userSelector, err))
+					return toolErr("login find trigger", fmt.Errorf("selector %q: %w", triggerSelector, err))
 				}
-				if err := el.SelectAllText(); err != nil {
-					return toolErr("login clear username", err)
+				if err := triggerEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
+					return toolErr("login click trigger", err)
 				}
-				if err := el.Input(username); err != nil {
-					return toolErr("login fill username", err)
+				// Wait for the form container to appear
+				if _, err := page.Timeout(5 * time.Second).Element(formContainer); err != nil {
+					return toolErr("login wait for form", fmt.Errorf("form container %q did not appear after clicking trigger: %w", formContainer, err))
 				}
-			} else {
-				// Try default selectors
-				filled := false
-				for _, sel := range defaultUsernameSelectors {
-					el, err := page.Element(sel)
-					if err == nil {
-						_ = el.SelectAllText()
-						if inputErr := el.Input(username); inputErr == nil {
-							filled = true
-							break
+				waitDOMStable(page)
+
+				// Scope selectors to form container for modal logins
+				if userSelector == "" {
+					// Try default selectors scoped to the form container
+					filled := false
+					for _, sel := range defaultUsernameSelectors {
+						scopedSel := formContainer + " " + sel
+						el, elErr := page.Element(scopedSel)
+						if elErr == nil {
+							if fillErr := loginSmartFill(el, username); fillErr == nil {
+								filled = true
+								break
+							}
 						}
 					}
+					if !filled {
+						return toolErr("login fill username", fmt.Errorf("could not find username field in %s; provide username_selector", formContainer))
+					}
+				} else {
+					el, err := page.Element(userSelector)
+					if err != nil {
+						return toolErr("login find username", fmt.Errorf("selector %q: %w", userSelector, err))
+					}
+					if err := loginSmartFill(el, username); err != nil {
+						return toolErr("login fill username", err)
+					}
 				}
-				if !filled {
-					return toolErr("login fill username", fmt.Errorf("could not find username field; provide username_selector"))
+
+				// Fill password (scoped to form container if no explicit selector)
+				passEl, err := page.Element(passSelector)
+				if err != nil {
+					// Try scoped selector
+					passEl, err = page.Element(formContainer + " " + passSelector)
+					if err != nil {
+						return toolErr("login find password", fmt.Errorf("selector %q: %w", passSelector, err))
+					}
 				}
-			}
+				if err := loginSmartFill(passEl, password); err != nil {
+					return toolErr("login fill password", err)
+				}
 
-			// Step 3: Fill password
-			passEl, err := page.Element(passSelector)
-			if err != nil {
-				return toolErr("login find password", fmt.Errorf("selector %q: %w", passSelector, err))
-			}
-			if err := passEl.SelectAllText(); err != nil {
-				return toolErr("login clear password", err)
-			}
-			if err := passEl.Input(password); err != nil {
-				return toolErr("login fill password", err)
-			}
+				// Submit (scoped to form container if no explicit selector)
+				submitEl, err := page.Element(submitSelector)
+				if err != nil {
+					submitEl, err = page.Element(formContainer + " " + submitSelector)
+					if err != nil {
+						return toolErr("login find submit", fmt.Errorf("selector %q: %w", submitSelector, err))
+					}
+				}
+				if err := submitEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
+					return toolErr("login click submit", err)
+				}
+			} else {
+				// Standard login page flow (no trigger)
 
-			// Step 4: Submit
-			submitEl, err := page.Element(submitSelector)
-			if err != nil {
-				return toolErr("login find submit", fmt.Errorf("selector %q: %w", submitSelector, err))
-			}
-			if err := submitEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
-				return toolErr("login click submit", err)
+				// Step 2: Find and fill username field
+				if userSelector != "" {
+					el, err := page.Element(userSelector)
+					if err != nil {
+						return toolErr("login find username", fmt.Errorf("selector %q: %w", userSelector, err))
+					}
+					if err := loginSmartFill(el, username); err != nil {
+						return toolErr("login fill username", err)
+					}
+				} else {
+					filled := false
+					for _, sel := range defaultUsernameSelectors {
+						el, err := page.Element(sel)
+						if err == nil {
+							if fillErr := loginSmartFill(el, username); fillErr == nil {
+								filled = true
+								break
+							}
+						}
+					}
+					if !filled {
+						return toolErr("login fill username", fmt.Errorf("could not find username field; provide username_selector"))
+					}
+				}
+
+				// Step 3: Fill password
+				passEl, err := page.Element(passSelector)
+				if err != nil {
+					return toolErr("login find password", fmt.Errorf("selector %q: %w", passSelector, err))
+				}
+				if err := loginSmartFill(passEl, password); err != nil {
+					return toolErr("login fill password", err)
+				}
+
+				// Step 4: Submit
+				submitEl, err := page.Element(submitSelector)
+				if err != nil {
+					return toolErr("login find submit", fmt.Errorf("selector %q: %w", submitSelector, err))
+				}
+				if err := submitEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
+					return toolErr("login click submit", err)
+				}
 			}
 
 			// Step 5: Verify success
@@ -213,4 +301,3 @@ var (
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
 	}
 )
-

--- a/tools/login.go
+++ b/tools/login.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/log"
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -60,7 +61,8 @@ func loginSmartFill(element *rod.Element, value string) error {
 		Value   string `json:"value"`
 	}
 	if parseErr := json.Unmarshal([]byte(obj.Value.Str()), &result); parseErr != nil {
-		return nil // can't parse but fill was attempted
+		log.Warnf("loginSmartFill: failed to parse smart fill result: %s", parseErr)
+		return nil // fill was attempted, can't verify
 	}
 	if !result.Success {
 		return fmt.Errorf("fill produced %q instead of expected value", result.Value)

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -46,8 +46,6 @@ var (
 // beforeunload dialog blocks navigation before our auto-accept fires).
 func simplePageAction(rodCtx *types.Context, name string, action func(*rod.Page) error) server.ToolHandlerFunc {
 	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// Navigation changes the page; invalidate so Execute rebuilds the snapshot.
-		rodCtx.InvalidateSnapshot()
 		page, err := rodCtx.ControlledPage()
 		if err != nil {
 			return toolErr(name, err)
@@ -65,8 +63,6 @@ func simplePageAction(rodCtx *types.Context, name string, action func(*rod.Page)
 var (
 	NavigationHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Navigation changes the page; invalidate so Execute rebuilds the snapshot.
-			rodCtx.InvalidateSnapshot()
 			args := request.GetArguments()
 			url, err := getStringArg(args, "url")
 			if err != nil {

--- a/tools/scroll.go
+++ b/tools/scroll.go
@@ -28,8 +28,6 @@ var (
 var (
 	ScrollHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Scrolling changes visible DOM area; invalidate so Execute rebuilds the snapshot.
-			rodCtx.InvalidateSnapshot()
 			page, err := rodCtx.ControlledPage()
 			if err != nil {
 				return toolErr("scroll", err)

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -83,8 +83,6 @@ var (
 
 	ClickHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Invalidate snapshot before acting so Execute rebuilds a fresh one after.
-			rodCtx.InvalidateSnapshot()
 			args := request.GetArguments()
 			page, element, ele, err := resolveSnapshotElement(rodCtx, args, "click element")
 			if err != nil {
@@ -139,8 +137,6 @@ var (
 
 	HoverHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Invalidate snapshot before acting so Execute rebuilds a fresh one after.
-			rodCtx.InvalidateSnapshot()
 			page, element, ele, err := resolveSnapshotElement(rodCtx, request.GetArguments(), "hover element")
 			if err != nil {
 				return toolErr("hover element", err)
@@ -157,8 +153,6 @@ var (
 
 	FillHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Invalidate snapshot before acting so Execute rebuilds a fresh one after.
-			rodCtx.InvalidateSnapshot()
 			page, element, ele, err := resolveSnapshotElement(rodCtx, request.GetArguments(), "fill element")
 			if err != nil {
 				return toolErr("fill element", err)
@@ -192,8 +186,6 @@ var (
 
 	SelectorHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Invalidate snapshot before acting so Execute rebuilds a fresh one after.
-			rodCtx.InvalidateSnapshot()
 			page, element, ele, err := resolveSnapshotElement(rodCtx, request.GetArguments(), "select option in element")
 			if err != nil {
 				return toolErr("select option", err)

--- a/tools/tabs.go
+++ b/tools/tabs.go
@@ -78,8 +78,6 @@ var (
 
 	TabSelectHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Switching tabs changes the active page; invalidate so Execute rebuilds the snapshot.
-			rodCtx.InvalidateSnapshot()
 			indexF, err := getFloatArg(request.GetArguments(), "index")
 			if err != nil {
 				return toolErr("select tab", err)

--- a/types/context.go
+++ b/types/context.go
@@ -168,12 +168,15 @@ func (ctx *Context) Execute(handlerFunc server.ToolHandlerFunc, handlerCallOpts 
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		// Invalidate the snapshot after every handler so stale refs are
-		// never reused.  Handlers are free to read the previous snapshot
-		// for ref-based element resolution during their execution because
-		// invalidation happens here, after they return.
-		ctx.InvalidateSnapshot()
 		if handlerCallOpts.WithSnapshot {
+			// Invalidate the snapshot after DOM-mutating handlers so stale
+			// refs are never reused.  Handlers are free to read the
+			// previous snapshot for ref-based element resolution during
+			// their execution because invalidation happens here, after
+			// they return.  Read-only handlers (WithSnapshot: false) do
+			// NOT invalidate, preserving the cached snapshot for
+			// subsequent ref-based tool calls.
+			ctx.InvalidateSnapshot()
 			snap, snapErr := ctx.EnsureSnapshot()
 			var snapshotText string
 			if snapErr != nil {

--- a/types/context.go
+++ b/types/context.go
@@ -168,10 +168,12 @@ func (ctx *Context) Execute(handlerFunc server.ToolHandlerFunc, handlerCallOpts 
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		// Invalidate the snapshot after every handler so stale refs are
+		// never reused.  Handlers are free to read the previous snapshot
+		// for ref-based element resolution during their execution because
+		// invalidation happens here, after they return.
+		ctx.InvalidateSnapshot()
 		if handlerCallOpts.WithSnapshot {
-			// Use EnsureSnapshot logic: only rebuild if the snapshot was invalidated
-			// (nil) by the handler. This avoids redundant rebuilds when the DOM was
-			// not modified (e.g. consecutive read-only tool calls reuse the cache).
 			snap, snapErr := ctx.EnsureSnapshot()
 			var snapshotText string
 			if snapErr != nil {

--- a/types/js/smart_fill.js
+++ b/types/js/smart_fill.js
@@ -23,6 +23,24 @@
         return el.value !== undefined ? el.value : el.textContent;
     }
 
+    // Helper: trigger React's onChange via internal __reactProps$.
+    // This ensures React's state is synchronized with the DOM value
+    // even when the fill method (clipboard, standard) doesn't fully
+    // propagate through React's synthetic event system.
+    function triggerReactOnChange(el) {
+        var keys = Object.keys(el);
+        for (var i = 0; i < keys.length; i++) {
+            if (keys[i].indexOf("__reactProps$") === 0) {
+                var props = el[keys[i]];
+                if (props && typeof props.onChange === "function") {
+                    props.onChange({ target: el, currentTarget: el });
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     // Helper: scroll into view and focus.
     function prepareElement(el) {
         el.scrollIntoView({ block: "center" });
@@ -126,6 +144,10 @@
         } else if (tryStandardInput(el, value)) {
             method = "react_standard_fallback";
         }
+        // Always trigger React's onChange to synchronize internal state
+        // with the DOM value.  Some fill methods update the DOM but
+        // don't fully propagate through React's synthetic event system.
+        triggerReactOnChange(el);
     }
 
     var finalValue = getValue(el);


### PR DESCRIPTION
## Summary

- **#243 — Snapshot ref resolution**: Moved `InvalidateSnapshot()` from individual handler starts into the `Execute` wrapper (after handler returns). Refs from the previous snapshot now remain valid during handler execution, fixing the "no snapshot available" error when using refs across consecutive tool calls. Also fixes ref-based `rod_batch` actions.

- **#242 — React fill state sync**: Added `triggerReactOnChange()` to `smart_fill.js` that calls the React `onChange` handler via `__reactProps$` after filling. Ensures React's internal state matches the DOM value even when clipboard/insertText methods don't propagate through React's synthetic event system.

- **#241 — Modal login support**: Added `trigger_selector` and `form_container` parameters to `rod_login`. When `trigger_selector` is set, the tool navigates to the URL, clicks the trigger to open the login form (e.g., a modal dialog), waits for the form container, then fills and submits within it. Also switched `rod_login` to use `smartFillElement` for React compatibility.

Closes #243, Closes #242, Closes #241

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `rod_snapshot` → `rod_click ref=...` works without extra snapshot call
- [ ] `rod_fill` on React controlled inputs triggers onChange (form submission includes values)
- [ ] `rod_login` with `trigger_selector` opens modal and completes login flow
- [ ] `rod_batch` with ref-based actions works (refs not invalidated between actions)