### PR TITLE
fix: rod_login and rod_navigate fail fast on HTTP errors

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -388,7 +388,7 @@ func TestE2E_Navigation(t *testing.T) {
 		start := time.Now()
 		result := h.callWithTimeout("rod_navigate", map[string]any{
 			"url": "https://the-internet.herokuapp.com/nonexistent-page-404",
-		}, timeoutMedium)
+		}, timeoutLong)
 		elapsed := time.Since(start)
 		assertContains(t, result, "HTTP 404")
 		if elapsed > 10*time.Second {
@@ -409,7 +409,7 @@ func TestE2E_Login(t *testing.T) {
 			"url":      "https://the-internet.herokuapp.com/nonexistent-login-404",
 			"username": "test@example.com",
 			"password": "password123",
-		}, timeoutMedium)
+		}, timeoutLong)
 		elapsed := time.Since(start)
 		assertContains(t, result, "HTTP 404")
 		if elapsed > 10*time.Second {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -383,6 +383,39 @@ func TestE2E_Navigation(t *testing.T) {
 		})
 		assertContainsAny(t, result, "visible", "found", "appeared")
 	})
+
+	t.Run("navigate_404_fails_fast", func(t *testing.T) {
+		start := time.Now()
+		result := h.callWithTimeout("rod_navigate", map[string]any{
+			"url": "https://the-internet.herokuapp.com/nonexistent-page-404",
+		}, timeoutMedium)
+		elapsed := time.Since(start)
+		assertContains(t, result, "HTTP 404")
+		if elapsed > 10*time.Second {
+			t.Errorf("expected fast failure but took %v", elapsed)
+		}
+	})
+}
+
+// TestE2E_Login tests the rod_login tool.
+func TestE2E_Login(t *testing.T) {
+	skipIfShort(t)
+	h := newHarness(t)
+	h.initialize()
+
+	t.Run("login_404_fails_fast", func(t *testing.T) {
+		start := time.Now()
+		result := h.callWithTimeout("rod_login", map[string]any{
+			"url":      "https://the-internet.herokuapp.com/nonexistent-login-404",
+			"username": "test@example.com",
+			"password": "password123",
+		}, timeoutMedium)
+		elapsed := time.Since(start)
+		assertContains(t, result, "HTTP 404")
+		if elapsed > 10*time.Second {
+			t.Errorf("expected fast failure but took %v", elapsed)
+		}
+	})
 }
 
 // TestE2E_Tabs tests tab_new, tab_list, tab_select, and tab_close.

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -28,18 +28,20 @@ func truncateContent(s string, maxLen int) (string, bool) {
 }
 
 // checkNavigationStatus inspects captured network requests for the navigated URL
-// and returns an error if the main document response has a non-2xx status code.
+// and returns an error if the main document response has a 4xx or 5xx status code.
 // This allows tools to fail fast instead of waiting for timeout on error pages.
+// Iterates from newest to oldest to handle stale entries in the ring buffer.
 func checkNavigationStatus(rodCtx *types.Context, url string) error {
 	requests := rodCtx.NetworkRequests(url, "", false)
-	for _, req := range requests {
+	for i := len(requests) - 1; i >= 0; i-- {
+		req := requests[i]
 		if req.Type != "Document" {
 			continue
 		}
 		if req.Status >= 400 {
 			return fmt.Errorf("page returned HTTP %d — check the URL", req.Status)
 		}
-		return nil // found the document request with a non-error status
+		return nil // found the most recent document request with a non-error status
 	}
 	return nil // no matching document request found — don't block
 }

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -27,6 +27,23 @@ func truncateContent(s string, maxLen int) (string, bool) {
 	return s[:maxLen], true
 }
 
+// checkNavigationStatus inspects captured network requests for the navigated URL
+// and returns an error if the main document response has a non-2xx status code.
+// This allows tools to fail fast instead of waiting for timeout on error pages.
+func checkNavigationStatus(rodCtx *types.Context, url string) error {
+	requests := rodCtx.NetworkRequests(url, "", false)
+	for _, req := range requests {
+		if req.Type != "Document" {
+			continue
+		}
+		if req.Status >= 400 {
+			return fmt.Errorf("page returned HTTP %d — check the URL", req.Status)
+		}
+		return nil // found the document request with a non-error status
+	}
+	return nil // no matching document request found — don't block
+}
+
 // waitDOMStable waits for the DOM to stabilize, logging errors at debug level.
 func waitDOMStable(page *rod.Page) {
 	if err := page.WaitDOMStable(defaultWaitStableDur, defaultDomDiff); err != nil {

--- a/tools/login.go
+++ b/tools/login.go
@@ -119,6 +119,11 @@ var (
 			}
 			waitDOMStable(page)
 
+			// Fail fast if the login page returned an HTTP error (e.g. 404)
+			if err := checkNavigationStatus(rodCtx, loginURL); err != nil {
+				return toolErr("login navigate", err)
+			}
+
 			// Step 1b: If trigger_selector is set, click it to open the login form
 			if triggerSelector != "" {
 				triggerEl, err := page.Element(triggerSelector)

--- a/tools/login.go
+++ b/tools/login.go
@@ -119,8 +119,13 @@ var (
 			}
 			waitDOMStable(page)
 
-			// Fail fast if the login page returned an HTTP error (e.g. 404)
-			if err := checkNavigationStatus(rodCtx, loginURL); err != nil {
+			// Fail fast if the login page returned an HTTP error (e.g. 404).
+			// Use the final page URL to handle redirects (e.g. http→https).
+			checkURL := loginURL
+			if pageInfo, infoErr := page.Info(); infoErr == nil && pageInfo.URL != "" {
+				checkURL = pageInfo.URL
+			}
+			if err := checkNavigationStatus(rodCtx, checkURL); err != nil {
 				return toolErr("login navigate", err)
 			}
 

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -93,6 +93,11 @@ var (
 			}
 			waitDOMStable(page)
 
+			// Fail fast if the page returned an HTTP error (e.g. 404, 500)
+			if err = checkNavigationStatus(rodCtx, url); err != nil {
+				return toolErr("navigate to "+url, err)
+			}
+
 			result := fmt.Sprintf("Navigated to %s", url)
 
 			// Append inline snapshot if requested

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -93,8 +93,13 @@ var (
 			}
 			waitDOMStable(page)
 
-			// Fail fast if the page returned an HTTP error (e.g. 404, 500)
-			if err = checkNavigationStatus(rodCtx, url); err != nil {
+			// Fail fast if the page returned an HTTP error (e.g. 404, 500).
+			// Use the final page URL to handle redirects (e.g. http→https).
+			checkURL := url
+			if info, infoErr := page.Info(); infoErr == nil && info.URL != "" {
+				checkURL = info.URL
+			}
+			if err = checkNavigationStatus(rodCtx, checkURL); err != nil {
 				return toolErr("navigate to "+url, err)
 			}
 


### PR DESCRIPTION
## Summary

- Add `checkNavigationStatus()` helper that inspects captured network requests for the main document response after navigation
- If the page returns HTTP 4xx/5xx, return a descriptive error immediately (e.g. "page returned HTTP 404 — check the URL") instead of waiting for the full timeout
- Applied to both `rod_login` and `rod_navigate`

## Changes

| File | Change |
|------|--------|
| `tools/helpers.go` | New `checkNavigationStatus()` helper |
| `tools/login.go` | Call helper after navigation/DOM stabilization |
| `tools/navigation.go` | Call helper after navigation/DOM stabilization |
| `e2e/e2e_test.go` | E2E tests for both tools against 404 pages |

## Test Plan

- [x] `go vet ./...` passes
- [x] `go build ./...` passes  
- [x] `go test ./...` passes
- [x] E2E: `TestE2E_Navigation/navigate_404_fails_fast` — verifies rod_navigate returns HTTP 404 error in <10s
- [x] E2E: `TestE2E_Login/login_404_fails_fast` — verifies rod_login returns HTTP 404 error in <10s

Fixes #256