### PR TITLE
refactor: error handling, login cleanup, and test coverage

### DIFF
--- a/tools/assert.go
+++ b/tools/assert.go
@@ -123,7 +123,10 @@ var (
 				}
 			}
 
-			out, _ := json.MarshalIndent(result, "", "  ")
+			out, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				return toolErr("marshal assert result", err)
+			}
 
 			if wantScreenshot {
 				bin, shotErr := page.Screenshot(false, &proto.PageCaptureScreenshot{

--- a/tools/batch.go
+++ b/tools/batch.go
@@ -123,11 +123,14 @@ var (
 				})
 			}
 
-			out, _ := json.MarshalIndent(map[string]interface{}{
+			out, marshalErr := json.MarshalIndent(map[string]interface{}{
 				"total":     len(actionsArr),
 				"completed": len(results),
 				"results":   results,
 			}, "", "  ")
+			if marshalErr != nil {
+				return toolErr("marshal batch result", marshalErr)
+			}
 			return mcp.NewToolResultText(string(out)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})

--- a/tools/compare.go
+++ b/tools/compare.go
@@ -120,7 +120,10 @@ var (
 				result["diff_image_path"] = diffPath
 			}
 
-			out, _ := json.MarshalIndent(result, "", "  ")
+			out, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				return toolErr("marshal compare result", err)
+			}
 			return mcp.NewToolResultText(string(out)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})

--- a/tools/constants.go
+++ b/tools/constants.go
@@ -28,6 +28,9 @@ const (
 	// defaultWaitTimeoutMs is the default timeout for wait operations in milliseconds.
 	defaultWaitTimeoutMs = 30000.0
 
+	// defaultLoginTimeoutMs is the default timeout for login success verification in milliseconds.
+	defaultLoginTimeoutMs = 15000.0
+
 	// dragStepDelay is the pause between mouse-move steps during drag operations.
 	dragStepDelay = 10 * time.Millisecond
 )

--- a/tools/constants.go
+++ b/tools/constants.go
@@ -31,6 +31,9 @@ const (
 	// defaultLoginTimeoutMs is the default timeout for login success verification in milliseconds.
 	defaultLoginTimeoutMs = 15000.0
 
+	// defaultFormContainerTimeout is the max time to wait for a modal form container to appear.
+	defaultFormContainerTimeout = 5 * time.Second
+
 	// dragStepDelay is the pause between mouse-move steps during drag operations.
 	dragStepDelay = 10 * time.Millisecond
 )

--- a/tools/download.go
+++ b/tools/download.go
@@ -137,12 +137,15 @@ var (
 				fileSize = stat.Size()
 			}
 
-			out, _ := json.MarshalIndent(map[string]interface{}{
+			out, err := json.MarshalIndent(map[string]interface{}{
 				"filename":    result.filename,
 				"path":        finalPath,
 				"size_bytes":  fileSize,
 				"download_url": result.url,
 			}, "", "  ")
+			if err != nil {
+				return toolErr("marshal download result", err)
+			}
 			return mcp.NewToolResultText(string(out)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})

--- a/tools/frames.go
+++ b/tools/frames.go
@@ -70,7 +70,10 @@ var (
 				"hint":   "Use ref-based targeting with frame prefix (e.g. f0e42 for element e42 in frame 0) to interact with elements inside iframes",
 			}
 
-			out, _ := json.MarshalIndent(result, "", "  ")
+			out, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				return toolErr("marshal frame list result", err)
+			}
 			return mcp.NewToolResultText(string(out)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})

--- a/tools/geolocation.go
+++ b/tools/geolocation.go
@@ -83,11 +83,14 @@ var (
 				return toolErr("set geolocation", setErr)
 			}
 
-			out, _ := json.MarshalIndent(map[string]interface{}{
+			out, marshalErr := json.MarshalIndent(map[string]interface{}{
 				"latitude":  lat,
 				"longitude": lng,
 				"accuracy":  accuracy,
 			}, "", "  ")
+			if marshalErr != nil {
+				return toolErr("marshal geolocation result", marshalErr)
+			}
 			return mcp.NewToolResultText(fmt.Sprintf("Geolocation set:\n%s", string(out))), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})

--- a/tools/login.go
+++ b/tools/login.go
@@ -68,40 +68,207 @@ func loginSmartFill(element *rod.Element, value string) error {
 	return nil
 }
 
+// loginParams holds parsed and defaulted parameters for the login flow.
+type loginParams struct {
+	loginURL        string
+	username        string
+	password        string
+	userSelector    string
+	passSelector    string
+	submitSelector  string
+	successSelector string
+	successURL      string
+	timeout         float64
+	triggerSelector string
+	formContainer   string
+}
+
+// parseLoginParams extracts and defaults login parameters from the MCP request.
+func parseLoginParams(args map[string]interface{}) (loginParams, error) {
+	loginURL, err := getStringArg(args, "url")
+	if err != nil {
+		return loginParams{}, err
+	}
+	username, err := getStringArg(args, "username")
+	if err != nil {
+		return loginParams{}, err
+	}
+	password, err := getStringArg(args, "password")
+	if err != nil {
+		return loginParams{}, err
+	}
+
+	p := loginParams{
+		loginURL:        loginURL,
+		username:        username,
+		password:        password,
+		userSelector:    getOptionalStringArg(args, "username_selector"),
+		passSelector:    getOptionalStringArg(args, "password_selector"),
+		submitSelector:  getOptionalStringArg(args, "submit_selector"),
+		successSelector: getOptionalStringArg(args, "success_selector"),
+		successURL:      getOptionalStringArg(args, "success_url_contains"),
+		timeout:         getOptionalFloatArg(args, "timeout", defaultLoginTimeoutMs),
+		triggerSelector: getOptionalStringArg(args, "trigger_selector"),
+		formContainer:   getOptionalStringArg(args, "form_container"),
+	}
+
+	if p.passSelector == "" {
+		p.passSelector = "input[type=password]"
+	}
+	if p.submitSelector == "" {
+		p.submitSelector = "button[type=submit]"
+	}
+	if p.formContainer == "" {
+		p.formContainer = "[role=dialog]"
+	}
+	return p, nil
+}
+
+// loginFillUsername finds and fills the username field on the page.
+// If userSelector is empty, tries defaultUsernameSelectors with optional scope prefix.
+func loginFillUsername(page *rod.Page, username, userSelector, scope string) error {
+	if userSelector != "" {
+		el, err := page.Element(userSelector)
+		if err != nil {
+			return fmt.Errorf("selector %q: %w", userSelector, err)
+		}
+		return loginSmartFill(el, username)
+	}
+
+	for _, sel := range defaultUsernameSelectors {
+		if scope != "" {
+			sel = scope + " " + sel
+		}
+		el, err := page.Element(sel)
+		if err == nil {
+			if fillErr := loginSmartFill(el, username); fillErr == nil {
+				return nil
+			}
+		}
+	}
+	if scope != "" {
+		return fmt.Errorf("could not find username field in %s; provide username_selector", scope)
+	}
+	return fmt.Errorf("could not find username field; provide username_selector")
+}
+
+// loginFillPassword finds and fills the password field, trying a scoped selector as fallback.
+func loginFillPassword(page *rod.Page, password, passSelector, scope string) error {
+	el, err := page.Element(passSelector)
+	if err != nil && scope != "" {
+		el, err = page.Element(scope + " " + passSelector)
+	}
+	if err != nil {
+		return fmt.Errorf("selector %q: %w", passSelector, err)
+	}
+	return loginSmartFill(el, password)
+}
+
+// loginSubmit finds and clicks the submit button, trying a scoped selector as fallback.
+func loginSubmit(page *rod.Page, submitSelector, scope string) error {
+	el, err := page.Element(submitSelector)
+	if err != nil && scope != "" {
+		el, err = page.Element(scope + " " + submitSelector)
+	}
+	if err != nil {
+		return fmt.Errorf("selector %q: %w", submitSelector, err)
+	}
+	return el.Click(proto.InputMouseButtonLeft, 1)
+}
+
+// loginOpenTrigger clicks a trigger element and waits for the form container to appear.
+func loginOpenTrigger(page *rod.Page, triggerSelector, formContainer string) error {
+	triggerEl, err := page.Element(triggerSelector)
+	if err != nil {
+		return fmt.Errorf("find trigger %q: %w", triggerSelector, err)
+	}
+	if err := triggerEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return fmt.Errorf("click trigger: %w", err)
+	}
+	if _, err := page.Timeout(5 * time.Second).Element(formContainer); err != nil {
+		return fmt.Errorf("form container %q did not appear after clicking trigger: %w", formContainer, err)
+	}
+	waitDOMStable(page)
+	return nil
+}
+
+// loginVerifySuccess polls for success indicators until timeout.
+func loginVerifySuccess(page *rod.Page, successSelector, successURL string, timeout float64) bool {
+	if successSelector == "" && successURL == "" {
+		if navErr := page.WaitLoad(); navErr == nil {
+			waitDOMStable(page)
+		}
+		return true
+	}
+
+	timeoutDur := time.Duration(timeout) * time.Millisecond
+	deadline := time.After(timeoutDur)
+	ticker := time.NewTicker(300 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if successSelector != "" {
+			if _, err := page.Element(successSelector); err == nil {
+				return true
+			}
+		}
+		if successURL != "" {
+			if info, err := page.Info(); err == nil && strings.Contains(info.URL, successURL) {
+				return true
+			}
+		}
+		select {
+		case <-deadline:
+			return false
+		case <-ticker.C:
+			continue
+		}
+	}
+}
+
+// loginBuildResult collects the login result (URL, title, cookies) into JSON.
+func loginBuildResult(page *rod.Page, verified bool, timeout float64) (string, error) {
+	info, infoErr := page.Info()
+	currentURL := ""
+	title := ""
+	if infoErr != nil {
+		log.Warnf("login page info: %s", infoErr)
+	} else if info != nil {
+		currentURL = info.URL
+		title = info.Title
+	}
+
+	resp, cookieErr := proto.NetworkGetCookies{}.Call(page)
+	cookieCount := 0
+	if cookieErr != nil {
+		log.Warnf("login get cookies: %s", cookieErr)
+	} else if resp != nil {
+		cookieCount = len(resp.Cookies)
+	}
+
+	result := map[string]interface{}{
+		"success":     verified,
+		"url":         currentURL,
+		"title":       title,
+		"cookies_set": cookieCount,
+	}
+	if !verified {
+		result["error"] = fmt.Sprintf("login verification timed out after %dms", int(timeout))
+	}
+
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal login result: %w", err)
+	}
+	return string(out), nil
+}
+
 var (
 	LoginHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			args := request.GetArguments()
-			loginURL, err := getStringArg(args, "url")
+			p, err := parseLoginParams(request.GetArguments())
 			if err != nil {
 				return toolErr("login", err)
-			}
-			username, err := getStringArg(args, "username")
-			if err != nil {
-				return toolErr("login", err)
-			}
-			password, err := getStringArg(args, "password")
-			if err != nil {
-				return toolErr("login", err)
-			}
-
-			userSelector := getOptionalStringArg(args, "username_selector")
-			passSelector := getOptionalStringArg(args, "password_selector")
-			submitSelector := getOptionalStringArg(args, "submit_selector")
-			successSelector := getOptionalStringArg(args, "success_selector")
-			successURL := getOptionalStringArg(args, "success_url_contains")
-			timeout := getOptionalFloatArg(args, "timeout", defaultLoginTimeoutMs)
-			triggerSelector := getOptionalStringArg(args, "trigger_selector")
-			formContainer := getOptionalStringArg(args, "form_container")
-
-			if passSelector == "" {
-				passSelector = "input[type=password]"
-			}
-			if submitSelector == "" {
-				submitSelector = "button[type=submit]"
-			}
-			if formContainer == "" {
-				formContainer = "[role=dialog]"
 			}
 
 			// Step 1: Navigate to login page
@@ -109,7 +276,7 @@ var (
 			if err != nil {
 				return toolErr("login navigate", err)
 			}
-			if err := page.Navigate(loginURL); err != nil {
+			if err := page.Navigate(p.loginURL); err != nil {
 				return toolErr("login navigate", err)
 			}
 			if err := page.WaitLoad(); err != nil {
@@ -118,8 +285,7 @@ var (
 			waitDOMStable(page)
 
 			// Fail fast if the login page returned an HTTP error (e.g. 404).
-			// Use the final page URL to handle redirects (e.g. http→https).
-			checkURL := loginURL
+			checkURL := p.loginURL
 			if pageInfo, infoErr := page.Info(); infoErr == nil && pageInfo.URL != "" {
 				checkURL = pageInfo.URL
 			}
@@ -127,193 +293,34 @@ var (
 				return toolErr("login navigate", err)
 			}
 
-			// Step 1b: If trigger_selector is set, click it to open the login form
-			if triggerSelector != "" {
-				triggerEl, err := page.Element(triggerSelector)
-				if err != nil {
-					return toolErr("login find trigger", fmt.Errorf("selector %q: %w", triggerSelector, err))
+			// Step 2: Fill credentials and submit
+			scope := "" // no scoping for standard login pages
+			if p.triggerSelector != "" {
+				if err := loginOpenTrigger(page, p.triggerSelector, p.formContainer); err != nil {
+					return toolErr("login trigger", err)
 				}
-				if err := triggerEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
-					return toolErr("login click trigger", err)
-				}
-				// Wait for the form container to appear
-				if _, err := page.Timeout(5 * time.Second).Element(formContainer); err != nil {
-					return toolErr("login wait for form", fmt.Errorf("form container %q did not appear after clicking trigger: %w", formContainer, err))
-				}
-				waitDOMStable(page)
-
-				// Scope selectors to form container for modal logins
-				if userSelector == "" {
-					// Try default selectors scoped to the form container
-					filled := false
-					for _, sel := range defaultUsernameSelectors {
-						scopedSel := formContainer + " " + sel
-						el, elErr := page.Element(scopedSel)
-						if elErr == nil {
-							if fillErr := loginSmartFill(el, username); fillErr == nil {
-								filled = true
-								break
-							}
-						}
-					}
-					if !filled {
-						return toolErr("login fill username", fmt.Errorf("could not find username field in %s; provide username_selector", formContainer))
-					}
-				} else {
-					el, err := page.Element(userSelector)
-					if err != nil {
-						return toolErr("login find username", fmt.Errorf("selector %q: %w", userSelector, err))
-					}
-					if err := loginSmartFill(el, username); err != nil {
-						return toolErr("login fill username", err)
-					}
-				}
-
-				// Fill password (scoped to form container if no explicit selector)
-				passEl, err := page.Element(passSelector)
-				if err != nil {
-					// Try scoped selector
-					passEl, err = page.Element(formContainer + " " + passSelector)
-					if err != nil {
-						return toolErr("login find password", fmt.Errorf("selector %q: %w", passSelector, err))
-					}
-				}
-				if err := loginSmartFill(passEl, password); err != nil {
-					return toolErr("login fill password", err)
-				}
-
-				// Submit (scoped to form container if no explicit selector)
-				submitEl, err := page.Element(submitSelector)
-				if err != nil {
-					submitEl, err = page.Element(formContainer + " " + submitSelector)
-					if err != nil {
-						return toolErr("login find submit", fmt.Errorf("selector %q: %w", submitSelector, err))
-					}
-				}
-				if err := submitEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
-					return toolErr("login click submit", err)
-				}
-			} else {
-				// Standard login page flow (no trigger)
-
-				// Step 2: Find and fill username field
-				if userSelector != "" {
-					el, err := page.Element(userSelector)
-					if err != nil {
-						return toolErr("login find username", fmt.Errorf("selector %q: %w", userSelector, err))
-					}
-					if err := loginSmartFill(el, username); err != nil {
-						return toolErr("login fill username", err)
-					}
-				} else {
-					filled := false
-					for _, sel := range defaultUsernameSelectors {
-						el, err := page.Element(sel)
-						if err == nil {
-							if fillErr := loginSmartFill(el, username); fillErr == nil {
-								filled = true
-								break
-							}
-						}
-					}
-					if !filled {
-						return toolErr("login fill username", fmt.Errorf("could not find username field; provide username_selector"))
-					}
-				}
-
-				// Step 3: Fill password
-				passEl, err := page.Element(passSelector)
-				if err != nil {
-					return toolErr("login find password", fmt.Errorf("selector %q: %w", passSelector, err))
-				}
-				if err := loginSmartFill(passEl, password); err != nil {
-					return toolErr("login fill password", err)
-				}
-
-				// Step 4: Submit
-				submitEl, err := page.Element(submitSelector)
-				if err != nil {
-					return toolErr("login find submit", fmt.Errorf("selector %q: %w", submitSelector, err))
-				}
-				if err := submitEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
-					return toolErr("login click submit", err)
-				}
+				scope = p.formContainer
 			}
 
-			// Step 5: Verify success
-			timeoutDur := time.Duration(timeout) * time.Millisecond
-			deadline := time.After(timeoutDur)
-			ticker := time.NewTicker(300 * time.Millisecond)
-			defer ticker.Stop()
-
-			verified := false
-			if successSelector == "" && successURL == "" {
-				// No explicit success check — wait for navigation to settle
-				if navErr := page.WaitLoad(); navErr == nil {
-					waitDOMStable(page)
-				}
-				verified = true
-			} else {
-				for {
-					if successSelector != "" {
-						if _, err := page.Element(successSelector); err == nil {
-							verified = true
-							break
-						}
-					}
-					if successURL != "" {
-						info, err := page.Info()
-						if err == nil {
-							if strings.Contains(info.URL, successURL) {
-								verified = true
-								break
-							}
-						}
-					}
-					select {
-					case <-deadline:
-						goto done
-					case <-ticker.C:
-						continue
-					}
-				}
+			if err := loginFillUsername(page, p.username, p.userSelector, scope); err != nil {
+				return toolErr("login fill username", err)
 			}
-		done:
-
-			info, infoErr := page.Info()
-			currentURL := ""
-			title := ""
-			if infoErr != nil {
-				log.Warnf("login page info: %s", infoErr)
-			} else if info != nil {
-				currentURL = info.URL
-				title = info.Title
+			if err := loginFillPassword(page, p.password, p.passSelector, scope); err != nil {
+				return toolErr("login fill password", err)
+			}
+			if err := loginSubmit(page, p.submitSelector, scope); err != nil {
+				return toolErr("login submit", err)
 			}
 
-			// Count cookies set
-			resp, cookieErr := proto.NetworkGetCookies{}.Call(page)
-			cookieCount := 0
-			if cookieErr != nil {
-				log.Warnf("login get cookies: %s", cookieErr)
-			} else if resp != nil {
-				cookieCount = len(resp.Cookies)
-			}
+			// Step 3: Verify success
+			verified := loginVerifySuccess(page, p.successSelector, p.successURL, p.timeout)
 
-			result := map[string]interface{}{
-				"success":     verified,
-				"url":         currentURL,
-				"title":       title,
-				"cookies_set": cookieCount,
+			// Step 4: Build result
+			out, err := loginBuildResult(page, verified, p.timeout)
+			if err != nil {
+				return toolErr("login", err)
 			}
-			if !verified {
-				result["error"] = fmt.Sprintf("login verification timed out after %dms", int(timeout))
-			}
-
-			out, marshalErr := json.MarshalIndent(result, "", "  ")
-			if marshalErr != nil {
-				return toolErr("login marshal result", marshalErr)
-			}
-			return mcp.NewToolResultText(string(out)), nil
+			return mcp.NewToolResultText(out), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})
 	}

--- a/tools/login.go
+++ b/tools/login.go
@@ -195,7 +195,7 @@ func loginOpenTrigger(page *rod.Page, triggerSelector, formContainer string) err
 	if err := triggerEl.Click(proto.InputMouseButtonLeft, 1); err != nil {
 		return fmt.Errorf("click trigger: %w", err)
 	}
-	if _, err := page.Timeout(5 * time.Second).Element(formContainer); err != nil {
+	if _, err := page.Timeout(defaultFormContainerTimeout).Element(formContainer); err != nil {
 		return fmt.Errorf("form container %q did not appear after clicking trigger: %w", formContainer, err)
 	}
 	waitDOMStable(page)
@@ -242,7 +242,7 @@ func loginBuildResult(page *rod.Page, verified bool, timeout float64) (string, e
 	currentURL := ""
 	title := ""
 	if infoErr != nil {
-		log.Warnf("login page info: %s", infoErr)
+		log.Debugf("login page info: %s", infoErr)
 	} else if info != nil {
 		currentURL = info.URL
 		title = info.Title
@@ -251,7 +251,7 @@ func loginBuildResult(page *rod.Page, verified bool, timeout float64) (string, e
 	resp, cookieErr := proto.NetworkGetCookies{}.Call(page)
 	cookieCount := 0
 	if cookieErr != nil {
-		log.Warnf("login get cookies: %s", cookieErr)
+		log.Debugf("login get cookies: %s", cookieErr)
 	} else if resp != nil {
 		cookieCount = len(resp.Cookies)
 	}

--- a/tools/login.go
+++ b/tools/login.go
@@ -84,7 +84,8 @@ type loginParams struct {
 }
 
 // parseLoginParams extracts and defaults login parameters from the MCP request.
-func parseLoginParams(args map[string]interface{}) (loginParams, error) {
+// Config-level defaults are used when the request doesn't specify selectors.
+func parseLoginParams(args map[string]interface{}, cfg types.Config) (loginParams, error) {
 	loginURL, err := getStringArg(args, "url")
 	if err != nil {
 		return loginParams{}, err
@@ -113,7 +114,13 @@ func parseLoginParams(args map[string]interface{}) (loginParams, error) {
 	}
 
 	if p.passSelector == "" {
+		p.passSelector = cfg.LoginPasswordSelector
+	}
+	if p.passSelector == "" {
 		p.passSelector = "input[type=password]"
+	}
+	if p.submitSelector == "" {
+		p.submitSelector = cfg.LoginSubmitSelector
 	}
 	if p.submitSelector == "" {
 		p.submitSelector = "button[type=submit]"
@@ -125,8 +132,8 @@ func parseLoginParams(args map[string]interface{}) (loginParams, error) {
 }
 
 // loginFillUsername finds and fills the username field on the page.
-// If userSelector is empty, tries defaultUsernameSelectors with optional scope prefix.
-func loginFillUsername(page *rod.Page, username, userSelector, scope string) error {
+// If userSelector is empty, tries the provided selectors (or defaults) with optional scope prefix.
+func loginFillUsername(page *rod.Page, username, userSelector, scope string, selectors []string) error {
 	if userSelector != "" {
 		el, err := page.Element(userSelector)
 		if err != nil {
@@ -135,7 +142,10 @@ func loginFillUsername(page *rod.Page, username, userSelector, scope string) err
 		return loginSmartFill(el, username)
 	}
 
-	for _, sel := range defaultUsernameSelectors {
+	if len(selectors) == 0 {
+		selectors = defaultUsernameSelectors
+	}
+	for _, sel := range selectors {
 		if scope != "" {
 			sel = scope + " " + sel
 		}
@@ -266,7 +276,8 @@ func loginBuildResult(page *rod.Page, verified bool, timeout float64) (string, e
 var (
 	LoginHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			p, err := parseLoginParams(request.GetArguments())
+			cfg := rodCtx.Config()
+			p, err := parseLoginParams(request.GetArguments(), cfg)
 			if err != nil {
 				return toolErr("login", err)
 			}
@@ -302,7 +313,7 @@ var (
 				scope = p.formContainer
 			}
 
-			if err := loginFillUsername(page, p.username, p.userSelector, scope); err != nil {
+			if err := loginFillUsername(page, p.username, p.userSelector, scope, cfg.LoginUsernameSelectors); err != nil {
 				return toolErr("login fill username", err)
 			}
 			if err := loginFillPassword(page, p.password, p.passSelector, scope); err != nil {

--- a/tools/login.go
+++ b/tools/login.go
@@ -280,18 +280,22 @@ var (
 			}
 		done:
 
-			info, _ := page.Info()
+			info, infoErr := page.Info()
 			currentURL := ""
 			title := ""
-			if info != nil {
+			if infoErr != nil {
+				log.Warnf("login page info: %s", infoErr)
+			} else if info != nil {
 				currentURL = info.URL
 				title = info.Title
 			}
 
 			// Count cookies set
-			resp, _ := proto.NetworkGetCookies{}.Call(page)
+			resp, cookieErr := proto.NetworkGetCookies{}.Call(page)
 			cookieCount := 0
-			if resp != nil {
+			if cookieErr != nil {
+				log.Warnf("login get cookies: %s", cookieErr)
+			} else if resp != nil {
 				cookieCount = len(resp.Cookies)
 			}
 
@@ -305,7 +309,10 @@ var (
 				result["error"] = fmt.Sprintf("login verification timed out after %dms", int(timeout))
 			}
 
-			out, _ := json.MarshalIndent(result, "", "  ")
+			out, marshalErr := json.MarshalIndent(result, "", "  ")
+			if marshalErr != nil {
+				return toolErr("login marshal result", marshalErr)
+			}
 			return mcp.NewToolResultText(string(out)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: true})

--- a/tools/login.go
+++ b/tools/login.go
@@ -19,8 +19,6 @@ import (
 
 const (
 	LoginToolKey = "rod_login"
-
-	defaultLoginTimeoutMs = 15000.0
 )
 
 var (

--- a/tools/login_test.go
+++ b/tools/login_test.go
@@ -1,0 +1,212 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+func TestLoginToolDefinition(t *testing.T) {
+	if Login.Name != LoginToolKey {
+		t.Errorf("Login tool name = %q, want %q", Login.Name, LoginToolKey)
+	}
+
+	props := Login.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Login tool has no properties")
+	}
+
+	required := []string{"url", "username", "password"}
+	for _, key := range required {
+		if _, ok := props[key]; !ok {
+			t.Errorf("Login tool missing required property %q", key)
+		}
+	}
+
+	optional := []string{
+		"username_selector", "password_selector", "submit_selector",
+		"success_selector", "success_url_contains", "timeout",
+		"trigger_selector", "form_container",
+	}
+	for _, key := range optional {
+		if _, ok := props[key]; !ok {
+			t.Errorf("Login tool missing optional property %q", key)
+		}
+	}
+}
+
+func TestParseLoginParams(t *testing.T) {
+	cfg := types.Config{}
+
+	t.Run("required fields", func(t *testing.T) {
+		args := map[string]interface{}{
+			"url":      "https://example.com/login",
+			"username": "user@test.com",
+			"password": "secret",
+		}
+		p, err := parseLoginParams(args, cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.loginURL != "https://example.com/login" {
+			t.Errorf("loginURL = %q, want %q", p.loginURL, "https://example.com/login")
+		}
+		if p.username != "user@test.com" {
+			t.Errorf("username = %q, want %q", p.username, "user@test.com")
+		}
+		if p.password != "secret" {
+			t.Errorf("password = %q, want %q", p.password, "secret")
+		}
+	})
+
+	t.Run("defaults", func(t *testing.T) {
+		args := map[string]interface{}{
+			"url":      "https://example.com/login",
+			"username": "user",
+			"password": "pass",
+		}
+		p, err := parseLoginParams(args, cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.passSelector != "input[type=password]" {
+			t.Errorf("passSelector = %q, want default", p.passSelector)
+		}
+		if p.submitSelector != "button[type=submit]" {
+			t.Errorf("submitSelector = %q, want default", p.submitSelector)
+		}
+		if p.formContainer != "[role=dialog]" {
+			t.Errorf("formContainer = %q, want default", p.formContainer)
+		}
+		if p.timeout != defaultLoginTimeoutMs {
+			t.Errorf("timeout = %v, want %v", p.timeout, defaultLoginTimeoutMs)
+		}
+	})
+
+	t.Run("config overrides defaults", func(t *testing.T) {
+		cfgOverride := types.Config{
+			LoginPasswordSelector: "#my-password",
+			LoginSubmitSelector:   "#my-submit",
+		}
+		args := map[string]interface{}{
+			"url":      "https://example.com/login",
+			"username": "user",
+			"password": "pass",
+		}
+		p, err := parseLoginParams(args, cfgOverride)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.passSelector != "#my-password" {
+			t.Errorf("passSelector = %q, want config override %q", p.passSelector, "#my-password")
+		}
+		if p.submitSelector != "#my-submit" {
+			t.Errorf("submitSelector = %q, want config override %q", p.submitSelector, "#my-submit")
+		}
+	})
+
+	t.Run("request overrides config", func(t *testing.T) {
+		cfgOverride := types.Config{
+			LoginPasswordSelector: "#config-password",
+			LoginSubmitSelector:   "#config-submit",
+		}
+		args := map[string]interface{}{
+			"url":               "https://example.com/login",
+			"username":          "user",
+			"password":          "pass",
+			"password_selector": "#request-password",
+			"submit_selector":   "#request-submit",
+		}
+		p, err := parseLoginParams(args, cfgOverride)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.passSelector != "#request-password" {
+			t.Errorf("passSelector = %q, want request override %q", p.passSelector, "#request-password")
+		}
+		if p.submitSelector != "#request-submit" {
+			t.Errorf("submitSelector = %q, want request override %q", p.submitSelector, "#request-submit")
+		}
+	})
+
+	t.Run("missing url", func(t *testing.T) {
+		args := map[string]interface{}{
+			"username": "user",
+			"password": "pass",
+		}
+		_, err := parseLoginParams(args, cfg)
+		if err == nil {
+			t.Error("expected error for missing url")
+		}
+	})
+
+	t.Run("missing username", func(t *testing.T) {
+		args := map[string]interface{}{
+			"url":      "https://example.com/login",
+			"password": "pass",
+		}
+		_, err := parseLoginParams(args, cfg)
+		if err == nil {
+			t.Error("expected error for missing username")
+		}
+	})
+
+	t.Run("missing password", func(t *testing.T) {
+		args := map[string]interface{}{
+			"url":      "https://example.com/login",
+			"username": "user",
+		}
+		_, err := parseLoginParams(args, cfg)
+		if err == nil {
+			t.Error("expected error for missing password")
+		}
+	})
+
+	t.Run("optional selectors", func(t *testing.T) {
+		args := map[string]interface{}{
+			"url":                  "https://example.com/login",
+			"username":             "user",
+			"password":             "pass",
+			"username_selector":    "#user",
+			"success_selector":     ".dashboard",
+			"success_url_contains": "/home",
+			"timeout":              5000.0,
+			"trigger_selector":     "#open-login",
+			"form_container":       "#login-modal",
+		}
+		p, err := parseLoginParams(args, cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.userSelector != "#user" {
+			t.Errorf("userSelector = %q, want %q", p.userSelector, "#user")
+		}
+		if p.successSelector != ".dashboard" {
+			t.Errorf("successSelector = %q, want %q", p.successSelector, ".dashboard")
+		}
+		if p.successURL != "/home" {
+			t.Errorf("successURL = %q, want %q", p.successURL, "/home")
+		}
+		if p.timeout != 5000.0 {
+			t.Errorf("timeout = %v, want %v", p.timeout, 5000.0)
+		}
+		if p.triggerSelector != "#open-login" {
+			t.Errorf("triggerSelector = %q, want %q", p.triggerSelector, "#open-login")
+		}
+		if p.formContainer != "#login-modal" {
+			t.Errorf("formContainer = %q, want %q", p.formContainer, "#login-modal")
+		}
+	})
+}
+
+func TestDefaultUsernameSelectors(t *testing.T) {
+	if len(defaultUsernameSelectors) == 0 {
+		t.Fatal("defaultUsernameSelectors should not be empty")
+	}
+	// Verify all selectors are valid CSS-like patterns
+	for _, sel := range defaultUsernameSelectors {
+		if sel == "" {
+			t.Error("empty selector in defaultUsernameSelectors")
+		}
+	}
+}

--- a/tools/race.go
+++ b/tools/race.go
@@ -97,7 +97,10 @@ var (
 				"text":             truncateRaceText(text),
 			}
 
-			out, _ := json.MarshalIndent(result, "", "  ")
+			out, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				return toolErr("marshal race result", err)
+			}
 			return mcp.NewToolResultText(string(out)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})

--- a/types/config.go
+++ b/types/config.go
@@ -52,6 +52,13 @@ type Config struct {
 	// "allow" (default): saves file and includes inline base64 ImageContent.
 	// "omit": saves file only, returns just the file path (saves tokens).
 	ImageResponses ImageResponsesMode `yaml:"imageResponses" json:"imageResponses"`
+	// LoginUsernameSelectors overrides the default username field selectors tried during login.
+	// If empty, the built-in defaults are used (input[type=email], input[name=email], etc.).
+	LoginUsernameSelectors []string `yaml:"loginUsernameSelectors" json:"loginUsernameSelectors"`
+	// LoginPasswordSelector overrides the default password field selector (input[type=password]).
+	LoginPasswordSelector string `yaml:"loginPasswordSelector" json:"loginPasswordSelector"`
+	// LoginSubmitSelector overrides the default submit button selector (button[type=submit]).
+	LoginSubmitSelector string `yaml:"loginSubmitSelector" json:"loginSubmitSelector"`
 }
 
 var (

--- a/types/context.go
+++ b/types/context.go
@@ -129,19 +129,19 @@ func (ctx *Context) initLocked() error {
 	if ctx.browser == nil {
 		ctx.browser, ctx.clonedProfileDir, err = launchBrowser(ctx.stdContext, ctx.config)
 		if err != nil {
-			return err
+			return fmt.Errorf("launch browser: %w", err)
 		}
 		ctx.startKeepalive()
 		ctx.page, err = ctx.createPage()
 		if err != nil {
-			return err
+			return fmt.Errorf("create initial page: %w", err)
 		}
 		return nil
 	}
 	if ctx.page == nil {
 		ctx.page, err = ctx.createPage()
 		if err != nil {
-			return err
+			return fmt.Errorf("create page: %w", err)
 		}
 	}
 
@@ -285,7 +285,7 @@ func (ctx *Context) closeBrowser() error {
 
 	err := ctx.closePage()
 	if err != nil {
-		return err
+		return fmt.Errorf("close browser: %w", err)
 	}
 
 	if ctx.browser == nil {

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -169,27 +169,37 @@ func (s *Snapshot) walkScalarNode(node *yaml.Node, frameIndex int, frame *rod.Pa
 	if node.Tag != "!!str" {
 		return node, nil
 	}
+	s.adjustFrameRef(node, frameIndex)
+	if result := s.tryExpandIframe(node, frame); result != nil {
+		return result, nil
+	}
+	s.accumulateRef(node.Value)
+	return node, nil
+}
 
-	value := node.Value
+// adjustFrameRef prefixes element refs with the frame index for cross-frame disambiguation.
+func (s *Snapshot) adjustFrameRef(node *yaml.Node, frameIndex int) {
 	if frameIndex > 0 {
-		node.Value = strings.Replace(value, "[ref=", fmt.Sprintf("[ref=f%d", frameIndex), 1)
+		node.Value = strings.Replace(node.Value, "[ref=", fmt.Sprintf("[ref=f%d", frameIndex), 1)
 	}
+}
 
-	if strings.HasPrefix(value, "iframe ") {
-		if result := s.walkIframeNode(node, frame); result != nil {
-			return result, nil
-		}
+// tryExpandIframe captures an iframe's snapshot inline if the node represents an iframe.
+// Returns the expanded node, or nil if the node is not an iframe.
+func (s *Snapshot) tryExpandIframe(node *yaml.Node, frame *rod.Page) *yaml.Node {
+	if strings.HasPrefix(node.Value, "iframe ") {
+		return s.walkIframeNode(node, frame)
 	}
+	return nil
+}
 
-	// Accumulate ref index entries during the walk (avoids a separate tree pass).
+// accumulateRef adds a ref index entry if the node value contains a ref pattern.
+func (s *Snapshot) accumulateRef(value string) {
 	if s.refAccum != nil {
-		effectiveValue := node.Value
-		if entry, ok := parseRefScalar(effectiveValue); ok {
+		if entry, ok := parseRefScalar(value); ok {
 			*s.refAccum = append(*s.refAccum, entry)
 		}
 	}
-
-	return node, nil
 }
 
 // walkIframeNode captures an iframe's snapshot and returns a mapping node with the result.

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/charmbracelet/log"
 	"github.com/go-rod/rod"
 	"gopkg.in/yaml.v3"
 
@@ -208,14 +209,19 @@ func (s *Snapshot) walkIframeNode(node *yaml.Node, frame *rod.Page) *yaml.Node {
 
 	childFrameEle, err := utils.QueryEleByAria(frame, ref)
 	if err != nil {
+		log.Debugf("walkIframeNode: query element for ref %q: %s", ref, err)
 		return pairNode
 	}
 	childFrame, err := childFrameEle.Frame()
 	if err != nil {
+		log.Debugf("walkIframeNode: get frame for ref %q: %s", ref, err)
 		return pairNode
 	}
 	childSnapshot, err := s.captureSnapshotWithFrames(childFrame)
 	if err != nil || len(childSnapshot.Content) == 0 {
+		if err != nil {
+			log.Debugf("walkIframeNode: capture snapshot for ref %q: %s", ref, err)
+		}
 		return pairNode
 	}
 


### PR DESCRIPTION
## Summary

Slot 10 refactoring batch — 9 issues addressing error handling, login code quality, and test coverage.

## Issues

| Issue | Change |
|-------|--------|
| #255 | Consolidate login timeout constant into constants.go |
| #249 | Wrap bare error returns in initLocked and closeBrowser |
| #250 | Handle ignored marshal and page.Info errors across 8 files |
| #251 | Add debug logging to walkIframeNode silent failures |
| #253 | Extract walkScalarNode into focused helper methods |
| #246 | Break LoginHandler into focused helpers (~40 lines of orchestration) |
| #247 | Deduplicate login credential-filling between trigger and standard paths |
| #254 | Make login selector defaults configurable via Config |
| #252 | Add unit tests for login parameter parsing and form detection |

## Key changes

- **LoginHandler**: Refactored from a 230-line monolith to ~40 lines of orchestration calling 7 focused helpers (`parseLoginParams`, `loginFillUsername`, `loginFillPassword`, `loginSubmit`, `loginOpenTrigger`, `loginVerifySuccess`, `loginBuildResult`)
- **Error handling**: All `json.MarshalIndent` and `page.Info()` ignored errors now handled (logged or returned)
- **Error context**: `initLocked` and `closeBrowser` wrap errors with `fmt.Errorf` for traceability
- **Observability**: `walkIframeNode` failures logged at debug level
- **Config**: Login selectors configurable via `loginUsernameSelectors`, `loginPasswordSelector`, `loginSubmitSelector`
- **Tests**: 10 new unit tests for login parameter parsing, config overrides, and defaults

## Test Plan

- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including 10 new login tests)
- [x] E2E: `TestE2E_Navigation` — all subtests pass including 404 fast-fail
- [x] E2E: `TestE2E_Login` — 404 fast-fail passes

Fixes #246, fixes #247, fixes #249, fixes #250, fixes #251, fixes #252, fixes #253, fixes #254, fixes #255