### PR TITLE
feat: add built-in stealth mode for anti-bot bypass

### DIFF
--- a/tools/configure.go
+++ b/tools/configure.go
@@ -17,6 +17,7 @@ var Configure = mcp.NewTool(ConfigureToolKey,
 	mcp.WithDescription("Configure browser settings. If the browser is already running it will be closed and restarted with the new settings on the next tool call."),
 	mcp.WithBoolean("headless", mcp.Description("Run the browser in headless mode (true) or with a visible GUI (false)")),
 	mcp.WithString("cdp_endpoint", mcp.Description("Connect to an existing Chrome instance via CDP endpoint URL (e.g. http://127.0.0.1:9222)")),
+	mcp.WithBoolean("stealth", mcp.Description("Enable stealth mode to bypass bot detection. Removes automation indicators, patches navigator.webdriver, injects realistic browser fingerprints, and sets a realistic User-Agent header.")),
 )
 
 var ConfigureHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
@@ -33,7 +34,12 @@ var ConfigureHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 			cdpEndpoint = &v
 		}
 
-		if err := rodCtx.Reconfigure(headless, cdpEndpoint); err != nil {
+		var stealth *bool
+		if v, ok := args["stealth"].(bool); ok {
+			stealth = &v
+		}
+
+		if err := rodCtx.Reconfigure(headless, cdpEndpoint, stealth); err != nil {
 			return toolErr("configure browser", err)
 		}
 
@@ -47,6 +53,9 @@ var ConfigureHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 			} else {
 				parts = append(parts, fmt.Sprintf("cdp_endpoint=%s", *cdpEndpoint))
 			}
+		}
+		if stealth != nil {
+			parts = append(parts, fmt.Sprintf("stealth=%t", *stealth))
 		}
 		if len(parts) == 0 {
 			return mcp.NewToolResultText("No configuration changes requested"), nil

--- a/tools/configure_test.go
+++ b/tools/configure_test.go
@@ -23,10 +23,13 @@ func TestConfigureToolDefinition(t *testing.T) {
 	if _, ok := props["cdp_endpoint"]; !ok {
 		t.Error("Configure tool missing 'cdp_endpoint' property")
 	}
+	if _, ok := props["stealth"]; !ok {
+		t.Error("Configure tool missing 'stealth' property")
+	}
 
-	// headless and cdp_endpoint should be optional (not required)
+	// headless, cdp_endpoint, and stealth should be optional (not required)
 	for _, r := range Configure.InputSchema.Required {
-		if r == "headless" || r == "cdp_endpoint" {
+		if r == "headless" || r == "cdp_endpoint" || r == "stealth" {
 			t.Errorf("Configure tool parameter %q should not be required", r)
 		}
 	}
@@ -146,6 +149,32 @@ func TestConfigureHandlerClearCDPEndpoint(t *testing.T) {
 
 	if rodCtx.Config().CDPEndpoint != "" {
 		t.Errorf("expected CDPEndpoint to be cleared, got %q", rodCtx.Config().CDPEndpoint)
+	}
+}
+
+func TestConfigureHandlerStealth(t *testing.T) {
+	cfg := types.DefaultConfig
+	cfg.Stealth = false
+	rodCtx := types.NewContext(context.Background(), cfg)
+	defer rodCtx.Close()
+
+	handler := ConfigureHandler(rodCtx)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"stealth": true,
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if text != "Browser configured: stealth=true. Changes take effect on next browser action." {
+		t.Errorf("unexpected result text: %s", text)
+	}
+
+	if !rodCtx.Config().Stealth {
+		t.Error("expected Stealth to be true after reconfigure")
 	}
 }
 

--- a/types/config.go
+++ b/types/config.go
@@ -59,6 +59,10 @@ type Config struct {
 	LoginPasswordSelector string `yaml:"loginPasswordSelector" json:"loginPasswordSelector"`
 	// LoginSubmitSelector overrides the default submit button selector (button[type=submit]).
 	LoginSubmitSelector string `yaml:"loginSubmitSelector" json:"loginSubmitSelector"`
+	// Stealth enables anti-bot-detection measures: removes automation indicators,
+	// patches navigator.webdriver, injects realistic browser fingerprints, and sets
+	// a realistic User-Agent header. Useful for automating sites with bot detection.
+	Stealth bool `yaml:"stealth" json:"stealth"`
 }
 
 var (

--- a/types/context.go
+++ b/types/context.go
@@ -352,8 +352,22 @@ func (ctx *Context) createPage(urls ...string) (*rod.Page, error) {
 		return nil, fmt.Errorf("inject snapshot script: %w", err)
 	}
 
-	// Apply HTTP headers from config (global + domain-specific)
+	// Inject stealth patches before any page JS runs.
+	if ctx.config.Stealth {
+		if _, err := page.EvalOnNewDocument(js.StealthJS); err != nil {
+			return nil, fmt.Errorf("inject stealth script: %w", err)
+		}
+		log.Debugf("stealth mode: injected anti-detection script on new page")
+	}
+
+	// When stealth is enabled, auto-set a realistic User-Agent and Sec-CH-UA
+	// header matching the running Chrome version, unless the user already
+	// configured those headers.
 	allHeaders := ctx.config.GetHeadersForURL(targetURL)
+	if ctx.config.Stealth {
+		allHeaders = ctx.applyStealthHeaders(allHeaders)
+	}
+
 	if len(allHeaders) > 0 {
 		if _, err := page.SetExtraHeaders(utils.HeaderMapToSlice(allHeaders)); err != nil {
 			return nil, fmt.Errorf("set extra HTTP headers: %w", err)
@@ -366,6 +380,69 @@ func (ctx *Context) createPage(urls ...string) (*rod.Page, error) {
 	return page, nil
 }
 
+// applyStealthHeaders sets realistic User-Agent and Sec-CH-UA headers derived
+// from the running Chrome version. Existing user-configured headers take
+// precedence — stealth only fills in missing values.
+func (ctx *Context) applyStealthHeaders(headers map[string]string) map[string]string {
+	if headers == nil {
+		headers = make(map[string]string)
+	}
+
+	// Fetch the Chrome version from the running browser.
+	chromeVersion := ctx.chromeVersion()
+
+	// Only set User-Agent if not already configured.
+	if _, ok := headers["User-Agent"]; !ok {
+		if chromeVersion != "" {
+			headers["User-Agent"] = fmt.Sprintf(
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36",
+				chromeVersion,
+			)
+		}
+	}
+
+	// Only set Sec-CH-UA if not already configured.
+	if _, ok := headers["Sec-CH-UA"]; !ok {
+		major := chromeMajorVersion(chromeVersion)
+		if major != "" {
+			headers["Sec-CH-UA"] = fmt.Sprintf(`"Chromium";v="%s", "Google Chrome";v="%s", "Not-A.Brand";v="99"`, major, major)
+		}
+	}
+
+	return headers
+}
+
+// chromeVersion returns the full Chrome version string (e.g. "124.0.6367.91")
+// from the running browser, or an empty string if unavailable.
+func (ctx *Context) chromeVersion() string {
+	if ctx.browser == nil {
+		return ""
+	}
+	res, err := proto.BrowserGetVersion{}.Call(ctx.browser)
+	if err != nil {
+		log.Debugf("stealth: failed to get browser version: %s", err)
+		return ""
+	}
+	// Product is typically "Chrome/124.0.6367.91" or "HeadlessChrome/124..."
+	product := res.Product
+	if idx := strings.Index(product, "/"); idx >= 0 {
+		return product[idx+1:]
+	}
+	return product
+}
+
+// chromeMajorVersion extracts the major version number from a full Chrome
+// version string (e.g. "124.0.6367.91" → "124").
+func chromeMajorVersion(version string) string {
+	if version == "" {
+		return ""
+	}
+	if idx := strings.Index(version, "."); idx > 0 {
+		return version[:idx]
+	}
+	return version
+}
+
 // UpdateHeadersForURL updates the extra HTTP headers on the current page based on the target URL.
 // This should be called before navigating to a new domain to ensure domain-specific headers are applied.
 func (ctx *Context) UpdateHeadersForURL(url string) error {
@@ -374,6 +451,9 @@ func (ctx *Context) UpdateHeadersForURL(url string) error {
 	}
 
 	allHeaders := ctx.config.GetHeadersForURL(url)
+	if ctx.config.Stealth {
+		allHeaders = ctx.applyStealthHeaders(allHeaders)
+	}
 	if len(allHeaders) > 0 {
 		if _, err := ctx.page.SetExtraHeaders(utils.HeaderMapToSlice(allHeaders)); err != nil {
 			return fmt.Errorf("set extra HTTP headers: %w", err)
@@ -385,7 +465,7 @@ func (ctx *Context) UpdateHeadersForURL(url string) error {
 // Reconfigure updates browser settings and closes any running browser so the
 // next tool call reinitializes with the new configuration.  Pass nil for any
 // field to leave it unchanged.
-func (ctx *Context) Reconfigure(headless *bool, cdpEndpoint *string) error {
+func (ctx *Context) Reconfigure(headless *bool, cdpEndpoint *string, stealth *bool) error {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
 
@@ -394,6 +474,9 @@ func (ctx *Context) Reconfigure(headless *bool, cdpEndpoint *string) error {
 	}
 	if cdpEndpoint != nil {
 		ctx.config.CDPEndpoint = *cdpEndpoint
+	}
+	if stealth != nil {
+		ctx.config.Stealth = *stealth
 	}
 
 	// Close existing browser so the next initial() picks up new config.

--- a/types/context_browser.go
+++ b/types/context_browser.go
@@ -145,6 +145,14 @@ func configureLauncher(ctx context.Context, cfg Config, userDataDir string) (*la
 		l.Proxy(cfg.Proxy)
 	}
 
+	if cfg.Stealth {
+		// Remove the automation indicator flag that Chromium sets by default.
+		l.Delete("enable-automation")
+		// Disable the Blink feature that exposes navigator.webdriver = true.
+		l.Set("disable-blink-features", "AutomationControlled")
+		log.Debugf("stealth mode: applied anti-detection launch flags")
+	}
+
 	return l, nil
 }
 

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -204,7 +204,8 @@ func TestReconfigure_UpdatesConfig(t *testing.T) {
 	headless := false
 	endpoint := "http://localhost:9222"
 
-	err := ctx.Reconfigure(&headless, &endpoint)
+	stealth := true
+	err := ctx.Reconfigure(&headless, &endpoint, &stealth)
 	if err != nil {
 		t.Fatalf("Reconfigure: unexpected error: %v", err)
 	}
@@ -215,6 +216,9 @@ func TestReconfigure_UpdatesConfig(t *testing.T) {
 	if ctx.config.CDPEndpoint != endpoint {
 		t.Errorf("Reconfigure: CDPEndpoint = %q, want %q", ctx.config.CDPEndpoint, endpoint)
 	}
+	if ctx.config.Stealth != true {
+		t.Error("Reconfigure: Stealth should be true")
+	}
 }
 
 func TestReconfigure_NilFields_NoChange(t *testing.T) {
@@ -222,16 +226,16 @@ func TestReconfigure_NilFields_NoChange(t *testing.T) {
 	ctx.config.Headless = true
 	ctx.config.CDPEndpoint = "http://existing"
 
-	err := ctx.Reconfigure(nil, nil)
+	err := ctx.Reconfigure(nil, nil, nil)
 	if err != nil {
-		t.Fatalf("Reconfigure(nil, nil): unexpected error: %v", err)
+		t.Fatalf("Reconfigure(nil, nil, nil): unexpected error: %v", err)
 	}
 
 	if ctx.config.Headless != true {
-		t.Error("Reconfigure(nil, nil): Headless should remain true")
+		t.Error("Reconfigure(nil, nil, nil): Headless should remain true")
 	}
 	if ctx.config.CDPEndpoint != "http://existing" {
-		t.Errorf("Reconfigure(nil, nil): CDPEndpoint changed unexpectedly to %q", ctx.config.CDPEndpoint)
+		t.Errorf("Reconfigure(nil, nil, nil): CDPEndpoint changed unexpectedly to %q", ctx.config.CDPEndpoint)
 	}
 }
 
@@ -277,5 +281,85 @@ func TestClose_WithTempDir_Cleanup(t *testing.T) {
 	err := ctx.Close()
 	if err != nil {
 		t.Errorf("Close with temp dir: unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stealth helpers
+// ---------------------------------------------------------------------------
+
+func TestChromeMajorVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"124.0.6367.91", "124"},
+		{"130.0.6723.58", "130"},
+		{"99", "99"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := chromeMajorVersion(tc.input)
+		if got != tc.want {
+			t.Errorf("chromeMajorVersion(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestApplyStealthHeaders_FillsMissingHeaders(t *testing.T) {
+	ctx := newTestContext()
+	ctx.config.Stealth = true
+	// No browser running, so chromeVersion returns "".
+	// applyStealthHeaders should not crash; headers should remain empty for version-dependent fields.
+	headers := ctx.applyStealthHeaders(nil)
+	if headers == nil {
+		t.Fatal("applyStealthHeaders returned nil")
+	}
+	// Without a running browser, User-Agent and Sec-CH-UA should not be set.
+	if _, ok := headers["User-Agent"]; ok {
+		t.Error("expected no User-Agent header without a running browser")
+	}
+	if _, ok := headers["Sec-CH-UA"]; ok {
+		t.Error("expected no Sec-CH-UA header without a running browser")
+	}
+}
+
+func TestApplyStealthHeaders_PreservesExistingHeaders(t *testing.T) {
+	ctx := newTestContext()
+	ctx.config.Stealth = true
+
+	existing := map[string]string{
+		"User-Agent": "CustomAgent/1.0",
+		"Sec-CH-UA":  `"Custom";v="1"`,
+	}
+	headers := ctx.applyStealthHeaders(existing)
+	if headers["User-Agent"] != "CustomAgent/1.0" {
+		t.Errorf("User-Agent was overwritten: %q", headers["User-Agent"])
+	}
+	if headers["Sec-CH-UA"] != `"Custom";v="1"` {
+		t.Errorf("Sec-CH-UA was overwritten: %q", headers["Sec-CH-UA"])
+	}
+}
+
+func TestReconfigure_Stealth(t *testing.T) {
+	ctx := newTestContext()
+	ctx.config.Stealth = false
+
+	stealth := true
+	err := ctx.Reconfigure(nil, nil, &stealth)
+	if err != nil {
+		t.Fatalf("Reconfigure stealth: unexpected error: %v", err)
+	}
+	if !ctx.config.Stealth {
+		t.Error("Reconfigure: Stealth should be true")
+	}
+
+	stealth = false
+	err = ctx.Reconfigure(nil, nil, &stealth)
+	if err != nil {
+		t.Fatalf("Reconfigure stealth=false: unexpected error: %v", err)
+	}
+	if ctx.config.Stealth {
+		t.Error("Reconfigure: Stealth should be false")
 	}
 }

--- a/types/js/js.go
+++ b/types/js/js.go
@@ -20,6 +20,9 @@ var WaitDetachedJS string
 //go:embed smart_fill.js
 var SmartFillJS string
 
+//go:embed stealth.js
+var StealthJS string
+
 const AriaSnapshot = "function(node, opts) { return snapshotEngine.ariaSnapshot(eval(node), eval(opts)); }"
 
 const QueryEleByAria = `(selector) => {

--- a/types/js/stealth.js
+++ b/types/js/stealth.js
@@ -1,0 +1,94 @@
+// stealth.js — Injected via Page.EvalOnNewDocument when stealth mode is enabled.
+// Patches browser APIs that bot-detection scripts probe to identify automation.
+// Must run before any page JavaScript executes.
+
+(function () {
+  'use strict';
+
+  // 1. navigator.webdriver → undefined
+  // Chromium sets this to true when --enable-automation is present or when
+  // controlled by DevTools protocol. Delete the property so typeof returns
+  // "undefined", matching a normal browser.
+  Object.defineProperty(navigator, 'webdriver', {
+    get: function () { return undefined; },
+    configurable: true,
+  });
+
+  // 2. navigator.plugins — inject a realistic plugin array.
+  // Headless/automated Chrome reports an empty PluginArray. Real Chrome on
+  // desktop typically has at least the PDF plugins.
+  var fakePlugins = [
+    { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+    { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai', description: '' },
+    { name: 'Chromium PDF Viewer', filename: 'internal-pdf-viewer', description: '' },
+  ];
+
+  var pluginArray = Object.create(PluginArray.prototype);
+  fakePlugins.forEach(function (p, i) {
+    var plugin = Object.create(Plugin.prototype);
+    Object.defineProperties(plugin, {
+      name:        { get: function () { return p.name; } },
+      filename:    { get: function () { return p.filename; } },
+      description: { get: function () { return p.description; } },
+      length:      { get: function () { return 0; } },
+    });
+    pluginArray[i] = plugin;
+  });
+  Object.defineProperty(pluginArray, 'length', { get: function () { return fakePlugins.length; } });
+  pluginArray.item = function (i) { return this[i] || null; };
+  pluginArray.namedItem = function (name) {
+    for (var i = 0; i < this.length; i++) {
+      if (this[i].name === name) return this[i];
+    }
+    return null;
+  };
+  pluginArray.refresh = function () {};
+
+  Object.defineProperty(navigator, 'plugins', {
+    get: function () { return pluginArray; },
+    configurable: true,
+  });
+
+  // 3. navigator.languages — ensure a realistic value.
+  Object.defineProperty(navigator, 'languages', {
+    get: function () { return ['en-US', 'en']; },
+    configurable: true,
+  });
+
+  // 4. window.chrome — inject a minimal Chrome runtime object.
+  // Bot detectors check for window.chrome existence and its runtime property.
+  if (!window.chrome) {
+    Object.defineProperty(window, 'chrome', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+  }
+  if (!window.chrome.runtime) {
+    window.chrome.runtime = {
+      connect: function () { return {}; },
+      sendMessage: function () {},
+    };
+  }
+
+  // 5. Remove cdc_ prefixed globals injected by ChromeDriver.
+  // These leak automation presence even when other patches are applied.
+  var cdcKeys = Object.getOwnPropertyNames(window).filter(function (k) {
+    return k.startsWith('cdc_') || k.startsWith('$cdc_');
+  });
+  cdcKeys.forEach(function (k) {
+    try { delete window[k]; } catch (e) { /* non-configurable — ignore */ }
+  });
+
+  // 6. Patch Permissions.query to report "prompt" for notifications.
+  // Automated browsers sometimes report "denied" which bot detectors flag.
+  var origQuery = window.Permissions && window.Permissions.prototype.query;
+  if (origQuery) {
+    window.Permissions.prototype.query = function (parameters) {
+      if (parameters && parameters.name === 'notifications') {
+        return Promise.resolve({ state: Notification.permission || 'prompt' });
+      }
+      return origQuery.call(this, parameters);
+    };
+  }
+})();


### PR DESCRIPTION
## Summary

- Add `stealth` boolean option to `rod_configure` and `Config` struct that enables anti-bot-detection measures
- Remove `--enable-automation` flag and add `--disable-blink-features=AutomationControlled` at browser launch when stealth is enabled
- Inject stealth JavaScript via `EvalOnNewDocument` before page scripts run, patching `navigator.webdriver`, `navigator.plugins`, `navigator.languages`, `window.chrome`, `Permissions.query`, and removing `cdc_` globals
- Auto-set realistic `User-Agent` and `Sec-CH-UA` headers derived from the running Chrome version (user-configured headers take precedence)
- Apply stealth headers on domain changes via `UpdateHeadersForURL`

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes — all new and existing tests green
- [ ] Manual test: enable stealth mode and visit a bot-detection test page (e.g. bot.sannysoft.com)

Fixes #258