### PR TITLE
feat: label stealth mode as EXPERIMENTAL

### DIFF
--- a/tools/configure.go
+++ b/tools/configure.go
@@ -17,7 +17,7 @@ var Configure = mcp.NewTool(ConfigureToolKey,
 	mcp.WithDescription("Configure browser settings. If the browser is already running it will be closed and restarted with the new settings on the next tool call."),
 	mcp.WithBoolean("headless", mcp.Description("Run the browser in headless mode (true) or with a visible GUI (false)")),
 	mcp.WithString("cdp_endpoint", mcp.Description("Connect to an existing Chrome instance via CDP endpoint URL (e.g. http://127.0.0.1:9222)")),
-	mcp.WithBoolean("stealth", mcp.Description("Enable stealth mode to bypass bot detection. Removes automation indicators, patches navigator.webdriver, injects realistic browser fingerprints, and sets a realistic User-Agent header.")),
+	mcp.WithBoolean("stealth", mcp.Description("[EXPERIMENTAL] Enable stealth mode to bypass bot detection. Removes automation indicators, patches navigator.webdriver, injects realistic browser fingerprints, and sets a realistic User-Agent header.")),
 )
 
 var ConfigureHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {

--- a/types/config.go
+++ b/types/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	// Stealth enables anti-bot-detection measures: removes automation indicators,
 	// patches navigator.webdriver, injects realistic browser fingerprints, and sets
 	// a realistic User-Agent header. Useful for automating sites with bot detection.
+	// EXPERIMENTAL: behavior may change between releases.
 	Stealth bool `yaml:"stealth" json:"stealth"`
 }
 

--- a/types/context_browser.go
+++ b/types/context_browser.go
@@ -150,7 +150,7 @@ func configureLauncher(ctx context.Context, cfg Config, userDataDir string) (*la
 		l.Delete("enable-automation")
 		// Disable the Blink feature that exposes navigator.webdriver = true.
 		l.Set("disable-blink-features", "AutomationControlled")
-		log.Debugf("stealth mode: applied anti-detection launch flags")
+		log.Warnf("experimental feature enabled: stealth mode — behavior may change between releases")
 	}
 
 	return l, nil


### PR DESCRIPTION
## Summary

- Add `[EXPERIMENTAL]` prefix to stealth parameter description in `rod_configure` tool (visible to MCP clients)
- Add `EXPERIMENTAL` annotation to `Stealth` field comment in config struct
- Upgrade stealth activation log from `Debugf` to `Warnf` with experimental notice

Establishes a convention for marking experimental features across the three key surfaces: tool descriptions, config comments, and runtime logs.

## Test plan

- [x] `go build` passes
- [x] `go test ./...` passes
- [x] No behavior changes — labeling only