### PR TITLE
refactor: split Context into focused sub-managers

### DIFF
--- a/types/context.go
+++ b/types/context.go
@@ -40,32 +40,19 @@ const (
 )
 
 type Context struct {
-	stdContext       context.Context
-	config          Config
-	browser         *rod.Browser
-	page            *rod.Page
+	stdContext context.Context
+	config     Config
+	browser    *rod.Browser
+	page       *rod.Page
 	// pageCancel cancels event-listener goroutines attached to the current page.
 	// It is set when attachEventListeners creates a cancelable page copy, and
 	// called in closePage before the page is closed.
-	pageCancel      func()
-	stateLock       sync.Mutex
-	snapshot        *Snapshot
-	mode            Mode
-	consoleMessages *RingBuffer[ConsoleMessage]
-	networkRequests *RingBuffer[NetworkRequest]
-	// pendingRequests tracks in-flight requests by ID for response correlation.
-	// Values are indices into the networkRequests ring buffer's internal items slice;
-	// they remain valid because the ring buffer never shifts elements.
-	pendingRequests map[string]int
-	// Intercept state
-	interceptRules   []InterceptRule
-	interceptEnabled bool
-	// interceptCancel cancels the EachEvent goroutine started by interceptEnable.
-	interceptCancel func()
-	// WebSocket tracking
-	wsConnections *RingBuffer[WebSocketConnection]
-	wsConnIndex   map[string]int // requestID → internal ring-buffer index in wsConnections
-	wsFrames      *RingBuffer[WebSocketFrame]
+	pageCancel func()
+	stateLock  sync.Mutex
+	snapshot   *Snapshot
+	mode       Mode
+	events     *EventCollector
+	intercept  *NetworkInterceptor
 	// clonedProfileDir is the temp directory from profile cloning, cleaned up on Close.
 	clonedProfileDir string
 	// keepaliveCancel stops the CDP keepalive goroutine when the browser is closed.
@@ -74,13 +61,11 @@ type Context struct {
 
 func NewContext(ctx context.Context, cfg Config) *Context {
 	return &Context{
-		stdContext:      ctx,
-		config:          cfg,
-		mode:            cfg.Mode,
-		consoleMessages: NewRingBuffer[ConsoleMessage](maxConsoleMessages),
-		networkRequests: NewRingBuffer[NetworkRequest](maxNetworkRequests),
-		wsConnections:   NewRingBuffer[WebSocketConnection](maxWSConnections),
-		wsFrames:        NewRingBuffer[WebSocketFrame](maxWSFrames),
+		stdContext: ctx,
+		config:     cfg,
+		mode:       cfg.Mode,
+		events:     NewEventCollector(),
+		intercept:  NewNetworkInterceptor(),
 	}
 }
 
@@ -264,10 +249,7 @@ func (ctx *Context) closePage() error {
 		ctx.pageCancel = nil
 	}
 	// Cancel any intercept listener goroutine as well.
-	if ctx.interceptCancel != nil {
-		ctx.interceptCancel()
-		ctx.interceptCancel = nil
-	}
+	ctx.intercept.Cancel()
 	err := ctx.page.Close()
 	if err != nil {
 		return fmt.Errorf("close page: %w", err)

--- a/types/context_events.go
+++ b/types/context_events.go
@@ -1,23 +1,11 @@
 package types
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
-)
-
-const (
-	// maxConsoleMessages is the maximum number of console messages retained.
-	maxConsoleMessages = 10000
-	// maxNetworkRequests is the maximum number of network requests retained.
-	maxNetworkRequests = 10000
-	// maxWSConnections is the maximum number of WebSocket connections retained.
-	maxWSConnections = 1000
-	// maxWSFrames is the maximum number of WebSocket frames retained.
-	maxWSFrames = 10000
 )
 
 // ConsoleMessage represents a captured browser console message.
@@ -77,71 +65,53 @@ func (ctx *Context) attachEventListeners(page *rod.Page) (cancel func()) {
 		}
 		text := strings.Join(parts, " ")
 		ctx.stateLock.Lock()
-		ctx.consoleMessages.Add(ConsoleMessage{
+		ctx.events.AddConsoleMessage(ConsoleMessage{
 			Level: string(e.Type),
 			Text:  text,
 		})
 		ctx.stateLock.Unlock()
 	}, func(e *proto.NetworkRequestWillBeSent) {
 		ctx.stateLock.Lock()
-		if ctx.pendingRequests == nil {
-			ctx.pendingRequests = make(map[string]int)
-		}
-		// AddWithIndex returns the internal ring-buffer slot index, which is
-		// stable until the slot is evicted by a future overflow.
-		idx := ctx.networkRequests.AddWithIndex(NetworkRequest{
+		ctx.events.AddNetworkRequest(NetworkRequest{
 			RequestID: string(e.RequestID),
 			Method:    e.Request.Method,
 			URL:       e.Request.URL,
 			Type:      string(e.Type),
 		})
-		ctx.pendingRequests[string(e.RequestID)] = idx
 		ctx.stateLock.Unlock()
 	}, func(e *proto.NetworkResponseReceived) {
 		ctx.stateLock.Lock()
-		if idx, ok := ctx.pendingRequests[string(e.RequestID)]; ok {
-			status := e.Response.Status
-			typ := string(e.Type)
-			ctx.networkRequests.UpdateAt(idx, func(req *NetworkRequest) {
-				req.Status = status
-				req.Type = typ
-			})
-			delete(ctx.pendingRequests, string(e.RequestID))
-		}
+		ctx.events.CompleteNetworkRequest(string(e.RequestID), e.Response.Status, string(e.Type))
 		ctx.stateLock.Unlock()
 	}, func(e *proto.NetworkWebSocketCreated) {
 		ctx.stateLock.Lock()
-		if ctx.wsConnIndex == nil {
-			ctx.wsConnIndex = make(map[string]int)
-		}
-		idx := ctx.wsConnections.AddWithIndex(WebSocketConnection{
+		ctx.events.AddWSConnection(WebSocketConnection{
 			RequestID: string(e.RequestID),
 			URL:       e.URL,
 		})
-		ctx.wsConnIndex[string(e.RequestID)] = idx
 		ctx.stateLock.Unlock()
 	}, func(e *proto.NetworkWebSocketFrameSent) {
 		ctx.stateLock.Lock()
-		if idx, ok := ctx.wsConnIndex[string(e.RequestID)]; ok {
-			ctx.wsConnections.UpdateAt(idx, func(conn *WebSocketConnection) {
+		if idx, ok := ctx.events.wsConnIndex[string(e.RequestID)]; ok {
+			ctx.events.wsConnections.UpdateAt(idx, func(conn *WebSocketConnection) {
 				conn.SentCount++
-				ctx.appendWSFrame(conn.URL, "sent", e.Response)
+				ctx.events.AppendWSFrame(conn.URL, "sent", e.Response)
 			})
 		}
 		ctx.stateLock.Unlock()
 	}, func(e *proto.NetworkWebSocketFrameReceived) {
 		ctx.stateLock.Lock()
-		if idx, ok := ctx.wsConnIndex[string(e.RequestID)]; ok {
-			ctx.wsConnections.UpdateAt(idx, func(conn *WebSocketConnection) {
+		if idx, ok := ctx.events.wsConnIndex[string(e.RequestID)]; ok {
+			ctx.events.wsConnections.UpdateAt(idx, func(conn *WebSocketConnection) {
 				conn.ReceivedCount++
-				ctx.appendWSFrame(conn.URL, "received", e.Response)
+				ctx.events.AppendWSFrame(conn.URL, "received", e.Response)
 			})
 		}
 		ctx.stateLock.Unlock()
 	}, func(e *proto.NetworkWebSocketClosed) {
 		ctx.stateLock.Lock()
-		if idx, ok := ctx.wsConnIndex[string(e.RequestID)]; ok {
-			ctx.wsConnections.UpdateAt(idx, func(conn *WebSocketConnection) {
+		if idx, ok := ctx.events.wsConnIndex[string(e.RequestID)]; ok {
+			ctx.events.wsConnections.UpdateAt(idx, func(conn *WebSocketConnection) {
 				conn.Closed = true
 			})
 		}
@@ -156,28 +126,7 @@ func (ctx *Context) attachEventListeners(page *rod.Page) (cancel func()) {
 func (ctx *Context) ConsoleMessages(filterLevel string, clear bool) []ConsoleMessage {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-
-	all := ctx.consoleMessages.Slice()
-	result := filterSlice(all, func(msg ConsoleMessage) bool {
-		return filterLevel == "" || msg.Level == filterLevel
-	})
-
-	if clear {
-		if filterLevel == "" {
-			ctx.consoleMessages.Clear()
-		} else {
-			// Rebuild the buffer keeping only non-matching messages.
-			fresh := NewRingBuffer[ConsoleMessage](maxConsoleMessages)
-			for _, msg := range filterSlice(all, func(msg ConsoleMessage) bool {
-				return msg.Level != filterLevel
-			}) {
-				fresh.Add(msg)
-			}
-			ctx.consoleMessages = fresh
-		}
-	}
-
-	return result
+	return ctx.events.ConsoleMessages(filterLevel, clear)
 }
 
 // NetworkRequests returns captured network requests, optionally filtered by URL pattern and method.
@@ -185,82 +134,33 @@ func (ctx *Context) ConsoleMessages(filterLevel string, clear bool) []ConsoleMes
 func (ctx *Context) NetworkRequests(filterURL, filterMethod string, clear bool) []NetworkRequest {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-
-	result := filterSlice(ctx.networkRequests.Slice(), func(req NetworkRequest) bool {
-		if filterURL != "" && !strings.Contains(req.URL, filterURL) {
-			return false
-		}
-		if filterMethod != "" && !strings.EqualFold(req.Method, filterMethod) {
-			return false
-		}
-		return true
-	})
-
-	if clear {
-		ctx.networkRequests.Clear()
-		ctx.pendingRequests = nil
-	}
-
-	return result
-}
-
-// appendWSFrame adds a WebSocket frame to the ring buffer (O(1), no copying).
-// Must be called with stateLock held.
-func (ctx *Context) appendWSFrame(url, direction string, frame *proto.NetworkWebSocketFrame) {
-	ctx.wsFrames.Add(WebSocketFrame{
-		URL:         url,
-		Direction:   direction,
-		PayloadData: frame.PayloadData,
-		Opcode:      int(frame.Opcode),
-	})
+	return ctx.events.NetworkRequests(filterURL, filterMethod, clear)
 }
 
 // GetRequestID returns the CDP request ID for a network request at the given index.
 func (ctx *Context) GetRequestID(index int) (string, error) {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-
-	all := ctx.networkRequests.Slice()
-	if len(all) == 0 {
-		return "", fmt.Errorf("no network requests captured")
-	}
-	if index < 0 || index >= len(all) {
-		return "", fmt.Errorf("request index %d out of range (0-%d)", index, len(all)-1)
-	}
-	return all[index].RequestID, nil
+	return ctx.events.GetRequestID(index)
 }
 
 // WebSocketConnections returns tracked WebSocket connections, optionally filtered by URL.
 func (ctx *Context) WebSocketConnections(urlFilter string) []WebSocketConnection {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-
-	return filterSlice(ctx.wsConnections.Slice(), func(conn WebSocketConnection) bool {
-		return urlFilter == "" || strings.Contains(conn.URL, urlFilter)
-	})
+	return ctx.events.WebSocketConnections(urlFilter)
 }
 
 // WebSocketFrames returns captured WebSocket frames, optionally filtered by URL and direction.
 func (ctx *Context) WebSocketFrames(urlFilter, direction string) []WebSocketFrame {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-
-	return filterSlice(ctx.wsFrames.Slice(), func(f WebSocketFrame) bool {
-		if urlFilter != "" && !strings.Contains(f.URL, urlFilter) {
-			return false
-		}
-		if direction != "" && f.Direction != direction {
-			return false
-		}
-		return true
-	})
+	return ctx.events.WebSocketFrames(urlFilter, direction)
 }
 
 // ClearWebSocketData clears all WebSocket connections and frames.
 func (ctx *Context) ClearWebSocketData() {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-	ctx.wsConnections.Clear()
-	ctx.wsConnIndex = nil
-	ctx.wsFrames.Clear()
+	ctx.events.ClearWebSocketData()
 }

--- a/types/context_events_test.go
+++ b/types/context_events_test.go
@@ -18,7 +18,7 @@ func addConsoleMessages(ctx *Context, msgs []ConsoleMessage) {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
 	for _, m := range msgs {
-		ctx.consoleMessages.Add(m)
+		ctx.events.consoleMessages.Add(m)
 	}
 }
 
@@ -27,7 +27,7 @@ func addNetworkRequests(ctx *Context, reqs []NetworkRequest) {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
 	for _, r := range reqs {
-		ctx.networkRequests.Add(r)
+		ctx.events.networkRequests.Add(r)
 	}
 }
 
@@ -36,7 +36,7 @@ func addWSFrames(ctx *Context, frames []WebSocketFrame) {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
 	for _, f := range frames {
-		ctx.wsFrames.Add(f)
+		ctx.events.wsFrames.Add(f)
 	}
 }
 
@@ -309,8 +309,8 @@ func TestWebSocketConnections_Empty(t *testing.T) {
 func TestWebSocketConnections_NoFilter(t *testing.T) {
 	ctx := newEventsContext()
 	ctx.stateLock.Lock()
-	ctx.wsConnections.Add(WebSocketConnection{RequestID: "ws1", URL: "wss://a.com/ws", Closed: false})
-	ctx.wsConnections.Add(WebSocketConnection{RequestID: "ws2", URL: "wss://b.com/ws", Closed: true})
+	ctx.events.wsConnections.Add(WebSocketConnection{RequestID: "ws1", URL: "wss://a.com/ws", Closed: false})
+	ctx.events.wsConnections.Add(WebSocketConnection{RequestID: "ws2", URL: "wss://b.com/ws", Closed: true})
 	ctx.stateLock.Unlock()
 
 	conns := ctx.WebSocketConnections("")
@@ -322,8 +322,8 @@ func TestWebSocketConnections_NoFilter(t *testing.T) {
 func TestWebSocketConnections_URLFilter(t *testing.T) {
 	ctx := newEventsContext()
 	ctx.stateLock.Lock()
-	ctx.wsConnections.Add(WebSocketConnection{RequestID: "ws1", URL: "wss://a.com/ws"})
-	ctx.wsConnections.Add(WebSocketConnection{RequestID: "ws2", URL: "wss://b.com/ws"})
+	ctx.events.wsConnections.Add(WebSocketConnection{RequestID: "ws1", URL: "wss://a.com/ws"})
+	ctx.events.wsConnections.Add(WebSocketConnection{RequestID: "ws2", URL: "wss://b.com/ws"})
 	ctx.stateLock.Unlock()
 
 	conns := ctx.WebSocketConnections("a.com")
@@ -421,8 +421,8 @@ func TestClearWebSocketData_ClearsAll(t *testing.T) {
 	ctx := newEventsContext()
 
 	ctx.stateLock.Lock()
-	idx := ctx.wsConnections.AddWithIndex(WebSocketConnection{RequestID: "ws1", URL: "wss://a.com"})
-	ctx.wsConnIndex = map[string]int{"ws1": idx}
+	idx := ctx.events.wsConnections.AddWithIndex(WebSocketConnection{RequestID: "ws1", URL: "wss://a.com"})
+	ctx.events.wsConnIndex = map[string]int{"ws1": idx}
 	ctx.stateLock.Unlock()
 	addWSFrames(ctx, []WebSocketFrame{
 		{URL: "wss://a.com", Direction: "sent", PayloadData: "data"},
@@ -441,7 +441,7 @@ func TestClearWebSocketData_ClearsAll(t *testing.T) {
 	}
 
 	ctx.stateLock.Lock()
-	connIndex := ctx.wsConnIndex
+	connIndex := ctx.events.wsConnIndex
 	ctx.stateLock.Unlock()
 	if connIndex != nil {
 		t.Error("wsConnIndex should be nil after clear")

--- a/types/context_intercept.go
+++ b/types/context_intercept.go
@@ -1,24 +1,10 @@
 package types
 
-import (
-	"github.com/go-rod/rod/lib/proto"
-)
-
-// InterceptRule defines a rule for how to handle an intercepted request.
-type InterceptRule struct {
-	URLPattern  string
-	Action      string // "mock", "block", "fail"
-	Status      int
-	Headers     []*proto.FetchHeaderEntry
-	Body        []byte
-	ErrorReason proto.NetworkErrorReason
-}
-
 // InterceptEnabled returns whether request interception is currently enabled.
 func (ctx *Context) InterceptEnabled() bool {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-	return ctx.interceptEnabled
+	return ctx.intercept.Enabled()
 }
 
 // SetInterceptEnabled sets whether interception is enabled.
@@ -26,39 +12,26 @@ func (ctx *Context) InterceptEnabled() bool {
 func (ctx *Context) SetInterceptEnabled(enabled bool) {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-	ctx.interceptEnabled = enabled
-	if !enabled {
-		ctx.interceptRules = nil
-		if ctx.interceptCancel != nil {
-			ctx.interceptCancel()
-			ctx.interceptCancel = nil
-		}
-	}
+	ctx.intercept.SetEnabled(enabled)
 }
 
 // SetInterceptCancel stores the cancel function for the intercept EachEvent goroutine.
 func (ctx *Context) SetInterceptCancel(cancel func()) {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-	// Cancel any prior listener before replacing.
-	if ctx.interceptCancel != nil {
-		ctx.interceptCancel()
-	}
-	ctx.interceptCancel = cancel
+	ctx.intercept.SetCancel(cancel)
 }
 
 // AddInterceptRule appends an interception rule.
 func (ctx *Context) AddInterceptRule(rule InterceptRule) {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-	ctx.interceptRules = append(ctx.interceptRules, rule)
+	ctx.intercept.AddRule(rule)
 }
 
 // InterceptRules returns a copy of the current interception rules.
 func (ctx *Context) InterceptRules() []InterceptRule {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
-	rules := make([]InterceptRule, len(ctx.interceptRules))
-	copy(rules, ctx.interceptRules)
-	return rules
+	return ctx.intercept.Rules()
 }

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -38,13 +38,16 @@ func TestNewContext_InitialState(t *testing.T) {
 	if ctx.snapshot != nil {
 		t.Error("snapshot should be nil on creation")
 	}
-	if ctx.consoleMessages == nil {
+	if ctx.events == nil {
+		t.Error("events collector should be initialized")
+	}
+	if ctx.events.consoleMessages == nil {
 		t.Error("consoleMessages ring buffer should be initialized")
 	}
-	if ctx.networkRequests == nil {
+	if ctx.events.networkRequests == nil {
 		t.Error("networkRequests ring buffer should be initialized")
 	}
-	if ctx.wsFrames == nil {
+	if ctx.events.wsFrames == nil {
 		t.Error("wsFrames ring buffer should be initialized")
 	}
 }

--- a/types/event_collector.go
+++ b/types/event_collector.go
@@ -1,0 +1,191 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-rod/rod/lib/proto"
+)
+
+const (
+	// maxConsoleMessages is the maximum number of console messages retained.
+	maxConsoleMessages = 10000
+	// maxNetworkRequests is the maximum number of network requests retained.
+	maxNetworkRequests = 10000
+	// maxWSConnections is the maximum number of WebSocket connections retained.
+	maxWSConnections = 1000
+	// maxWSFrames is the maximum number of WebSocket frames retained.
+	maxWSFrames = 10000
+)
+
+// EventCollector owns the ring buffers for console messages, network requests,
+// and WebSocket tracking. All methods assume the caller holds Context.stateLock.
+type EventCollector struct {
+	consoleMessages *RingBuffer[ConsoleMessage]
+	networkRequests *RingBuffer[NetworkRequest]
+	// pendingRequests tracks in-flight requests by ID for response correlation.
+	// Values are indices into the networkRequests ring buffer's internal items slice;
+	// they remain valid because the ring buffer never shifts elements.
+	pendingRequests map[string]int
+	// WebSocket tracking
+	wsConnections *RingBuffer[WebSocketConnection]
+	wsConnIndex   map[string]int // requestID → internal ring-buffer index in wsConnections
+	wsFrames      *RingBuffer[WebSocketFrame]
+}
+
+// NewEventCollector creates an EventCollector with default-sized ring buffers.
+func NewEventCollector() *EventCollector {
+	return &EventCollector{
+		consoleMessages: NewRingBuffer[ConsoleMessage](maxConsoleMessages),
+		networkRequests: NewRingBuffer[NetworkRequest](maxNetworkRequests),
+		wsConnections:   NewRingBuffer[WebSocketConnection](maxWSConnections),
+		wsFrames:        NewRingBuffer[WebSocketFrame](maxWSFrames),
+	}
+}
+
+// AddConsoleMessage records a console message. Must be called with stateLock held.
+func (ec *EventCollector) AddConsoleMessage(msg ConsoleMessage) {
+	ec.consoleMessages.Add(msg)
+}
+
+// AddNetworkRequest records a new outgoing request and tracks it as pending.
+// Must be called with stateLock held.
+func (ec *EventCollector) AddNetworkRequest(req NetworkRequest) {
+	if ec.pendingRequests == nil {
+		ec.pendingRequests = make(map[string]int)
+	}
+	idx := ec.networkRequests.AddWithIndex(req)
+	ec.pendingRequests[req.RequestID] = idx
+}
+
+// CompleteNetworkRequest updates a pending request with its response status and type.
+// Must be called with stateLock held.
+func (ec *EventCollector) CompleteNetworkRequest(requestID string, status int, typ string) {
+	if idx, ok := ec.pendingRequests[requestID]; ok {
+		ec.networkRequests.UpdateAt(idx, func(req *NetworkRequest) {
+			req.Status = status
+			req.Type = typ
+		})
+		delete(ec.pendingRequests, requestID)
+	}
+}
+
+// AddWSConnection records a new WebSocket connection. Must be called with stateLock held.
+func (ec *EventCollector) AddWSConnection(conn WebSocketConnection) {
+	if ec.wsConnIndex == nil {
+		ec.wsConnIndex = make(map[string]int)
+	}
+	idx := ec.wsConnections.AddWithIndex(conn)
+	ec.wsConnIndex[conn.RequestID] = idx
+}
+
+// UpdateWSConnection calls fn on the WebSocket connection identified by requestID.
+// Must be called with stateLock held.
+func (ec *EventCollector) UpdateWSConnection(requestID string, fn func(*WebSocketConnection)) {
+	if idx, ok := ec.wsConnIndex[requestID]; ok {
+		ec.wsConnections.UpdateAt(idx, fn)
+	}
+}
+
+// AppendWSFrame adds a WebSocket frame to the ring buffer.
+// Must be called with stateLock held.
+func (ec *EventCollector) AppendWSFrame(url, direction string, frame *proto.NetworkWebSocketFrame) {
+	ec.wsFrames.Add(WebSocketFrame{
+		URL:         url,
+		Direction:   direction,
+		PayloadData: frame.PayloadData,
+		Opcode:      int(frame.Opcode),
+	})
+}
+
+// ConsoleMessages returns captured console messages, optionally filtered by level.
+// If clear is true, the buffer is emptied after returning.
+// Must be called with stateLock held.
+func (ec *EventCollector) ConsoleMessages(filterLevel string, clear bool) []ConsoleMessage {
+	all := ec.consoleMessages.Slice()
+	result := filterSlice(all, func(msg ConsoleMessage) bool {
+		return filterLevel == "" || msg.Level == filterLevel
+	})
+
+	if clear {
+		if filterLevel == "" {
+			ec.consoleMessages.Clear()
+		} else {
+			// Rebuild the buffer keeping only non-matching messages.
+			fresh := NewRingBuffer[ConsoleMessage](maxConsoleMessages)
+			for _, msg := range filterSlice(all, func(msg ConsoleMessage) bool {
+				return msg.Level != filterLevel
+			}) {
+				fresh.Add(msg)
+			}
+			ec.consoleMessages = fresh
+		}
+	}
+
+	return result
+}
+
+// NetworkRequests returns captured network requests, optionally filtered by URL pattern and method.
+// If clear is true, the buffer is emptied after returning.
+// Must be called with stateLock held.
+func (ec *EventCollector) NetworkRequests(filterURL, filterMethod string, clear bool) []NetworkRequest {
+	result := filterSlice(ec.networkRequests.Slice(), func(req NetworkRequest) bool {
+		if filterURL != "" && !strings.Contains(req.URL, filterURL) {
+			return false
+		}
+		if filterMethod != "" && !strings.EqualFold(req.Method, filterMethod) {
+			return false
+		}
+		return true
+	})
+
+	if clear {
+		ec.networkRequests.Clear()
+		ec.pendingRequests = nil
+	}
+
+	return result
+}
+
+// GetRequestID returns the CDP request ID for a network request at the given index.
+// Must be called with stateLock held.
+func (ec *EventCollector) GetRequestID(index int) (string, error) {
+	all := ec.networkRequests.Slice()
+	if len(all) == 0 {
+		return "", fmt.Errorf("no network requests captured")
+	}
+	if index < 0 || index >= len(all) {
+		return "", fmt.Errorf("request index %d out of range (0-%d)", index, len(all)-1)
+	}
+	return all[index].RequestID, nil
+}
+
+// WebSocketConnections returns tracked WebSocket connections, optionally filtered by URL.
+// Must be called with stateLock held.
+func (ec *EventCollector) WebSocketConnections(urlFilter string) []WebSocketConnection {
+	return filterSlice(ec.wsConnections.Slice(), func(conn WebSocketConnection) bool {
+		return urlFilter == "" || strings.Contains(conn.URL, urlFilter)
+	})
+}
+
+// WebSocketFrames returns captured WebSocket frames, optionally filtered by URL and direction.
+// Must be called with stateLock held.
+func (ec *EventCollector) WebSocketFrames(urlFilter, direction string) []WebSocketFrame {
+	return filterSlice(ec.wsFrames.Slice(), func(f WebSocketFrame) bool {
+		if urlFilter != "" && !strings.Contains(f.URL, urlFilter) {
+			return false
+		}
+		if direction != "" && f.Direction != direction {
+			return false
+		}
+		return true
+	})
+}
+
+// ClearWebSocketData clears all WebSocket connections and frames.
+// Must be called with stateLock held.
+func (ec *EventCollector) ClearWebSocketData() {
+	ec.wsConnections.Clear()
+	ec.wsConnIndex = nil
+	ec.wsFrames.Clear()
+}

--- a/types/network_interceptor.go
+++ b/types/network_interceptor.go
@@ -1,0 +1,82 @@
+package types
+
+import (
+	"github.com/go-rod/rod/lib/proto"
+)
+
+// NetworkInterceptor owns the state for CDP request interception (Fetch domain).
+// All methods assume the caller holds Context.stateLock.
+type NetworkInterceptor struct {
+	rules   []InterceptRule
+	enabled bool
+	// cancel cancels the EachEvent goroutine started by interceptEnable.
+	cancel func()
+}
+
+// NewNetworkInterceptor creates a NetworkInterceptor with no rules and interception disabled.
+func NewNetworkInterceptor() *NetworkInterceptor {
+	return &NetworkInterceptor{}
+}
+
+// InterceptRule defines a rule for how to handle an intercepted request.
+type InterceptRule struct {
+	URLPattern  string
+	Action      string // "mock", "block", "fail"
+	Status      int
+	Headers     []*proto.FetchHeaderEntry
+	Body        []byte
+	ErrorReason proto.NetworkErrorReason
+}
+
+// Enabled returns whether request interception is currently enabled.
+// Must be called with stateLock held.
+func (ni *NetworkInterceptor) Enabled() bool {
+	return ni.enabled
+}
+
+// SetEnabled sets whether interception is enabled.
+// When disabling, any existing intercept listener goroutine is cancelled and rules are cleared.
+// Must be called with stateLock held.
+func (ni *NetworkInterceptor) SetEnabled(enabled bool) {
+	ni.enabled = enabled
+	if !enabled {
+		ni.rules = nil
+		if ni.cancel != nil {
+			ni.cancel()
+			ni.cancel = nil
+		}
+	}
+}
+
+// SetCancel stores the cancel function for the intercept EachEvent goroutine.
+// Any prior listener is cancelled before replacing.
+// Must be called with stateLock held.
+func (ni *NetworkInterceptor) SetCancel(cancel func()) {
+	if ni.cancel != nil {
+		ni.cancel()
+	}
+	ni.cancel = cancel
+}
+
+// Cancel cancels the intercept listener goroutine if one is running, and
+// clears the cancel function. Must be called with stateLock held.
+func (ni *NetworkInterceptor) Cancel() {
+	if ni.cancel != nil {
+		ni.cancel()
+		ni.cancel = nil
+	}
+}
+
+// AddRule appends an interception rule.
+// Must be called with stateLock held.
+func (ni *NetworkInterceptor) AddRule(rule InterceptRule) {
+	ni.rules = append(ni.rules, rule)
+}
+
+// Rules returns a copy of the current interception rules.
+// Must be called with stateLock held.
+func (ni *NetworkInterceptor) Rules() []InterceptRule {
+	rules := make([]InterceptRule, len(ni.rules))
+	copy(rules, ni.rules)
+	return rules
+}


### PR DESCRIPTION
## Summary

- Extract `EventCollector` type owning console messages, network requests, and WebSocket tracking state (6 fields + associated methods)
- Extract `NetworkInterceptor` type owning intercept rules, enabled flag, and cancel function (3 fields + associated methods)
- Context struct reduced from 20 fields to 12, delegating to sub-managers
- All public Context methods remain as thin delegators — zero changes to tool code in `tools/`

## Test plan

- [x] `go build -o /dev/null` passes
- [x] `go test ./...` passes (all existing tests green, no skips)
- [ ] CI passes

Closes #248