### PR TITLE
fix: address unresolved Copilot review comments from PRs #260-263

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	// Stealth enables anti-bot-detection measures: removes automation indicators,
 	// patches navigator.webdriver, injects realistic browser fingerprints, and sets
 	// a realistic User-Agent header. Useful for automating sites with bot detection.
-	// EXPERIMENTAL: behavior may change between releases.
+	// [EXPERIMENTAL] behavior may change between releases.
 	Stealth bool `yaml:"stealth" json:"stealth"`
 }
 

--- a/types/context.go
+++ b/types/context.go
@@ -51,8 +51,8 @@ type Context struct {
 	stateLock  sync.Mutex
 	snapshot   *Snapshot
 	mode       Mode
-	events     *EventCollector
-	intercept  *NetworkInterceptor
+	events     *eventCollector
+	intercept  *networkInterceptor
 	// clonedProfileDir is the temp directory from profile cloning, cleaned up on Close.
 	clonedProfileDir string
 	// keepaliveCancel stops the CDP keepalive goroutine when the browser is closed.
@@ -64,8 +64,8 @@ func NewContext(ctx context.Context, cfg Config) *Context {
 		stdContext: ctx,
 		config:     cfg,
 		mode:       cfg.Mode,
-		events:     NewEventCollector(),
-		intercept:  NewNetworkInterceptor(),
+		events:     newEventCollector(),
+		intercept:  newNetworkInterceptor(),
 	}
 }
 
@@ -373,8 +373,9 @@ func (ctx *Context) applyStealthHeaders(headers map[string]string) map[string]st
 	// Fetch the Chrome version from the running browser.
 	chromeVersion := ctx.chromeVersion()
 
-	// Only set User-Agent if not already configured.
-	if _, ok := headers["User-Agent"]; !ok {
+	// Only set User-Agent if not already configured (case-insensitive check
+	// since HTTP header names are case-insensitive).
+	if !headerExists(headers, "User-Agent") {
 		if chromeVersion != "" {
 			headers["User-Agent"] = fmt.Sprintf(
 				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36",
@@ -383,8 +384,8 @@ func (ctx *Context) applyStealthHeaders(headers map[string]string) map[string]st
 		}
 	}
 
-	// Only set Sec-CH-UA if not already configured.
-	if _, ok := headers["Sec-CH-UA"]; !ok {
+	// Only set Sec-CH-UA if not already configured (case-insensitive).
+	if !headerExists(headers, "Sec-CH-UA") {
 		major := chromeMajorVersion(chromeVersion)
 		if major != "" {
 			headers["Sec-CH-UA"] = fmt.Sprintf(`"Chromium";v="%s", "Google Chrome";v="%s", "Not-A.Brand";v="99"`, major, major)
@@ -411,6 +412,17 @@ func (ctx *Context) chromeVersion() string {
 		return product[idx+1:]
 	}
 	return product
+}
+
+// headerExists checks whether a header name is present in the map using a
+// case-insensitive comparison, since HTTP header names are case-insensitive.
+func headerExists(headers map[string]string, name string) bool {
+	for k := range headers {
+		if strings.EqualFold(k, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // chromeMajorVersion extracts the major version number from a full Chrome

--- a/types/context_browser.go
+++ b/types/context_browser.go
@@ -150,7 +150,7 @@ func configureLauncher(ctx context.Context, cfg Config, userDataDir string) (*la
 		l.Delete("enable-automation")
 		// Disable the Blink feature that exposes navigator.webdriver = true.
 		l.Set("disable-blink-features", "AutomationControlled")
-		log.Warnf("experimental feature enabled: stealth mode — behavior may change between releases")
+		log.Infof("[EXPERIMENTAL] stealth mode enabled — behavior may change between releases")
 	}
 
 	return l, nil

--- a/types/context_events.go
+++ b/types/context_events.go
@@ -92,29 +92,23 @@ func (ctx *Context) attachEventListeners(page *rod.Page) (cancel func()) {
 		ctx.stateLock.Unlock()
 	}, func(e *proto.NetworkWebSocketFrameSent) {
 		ctx.stateLock.Lock()
-		if idx, ok := ctx.events.wsConnIndex[string(e.RequestID)]; ok {
-			ctx.events.wsConnections.UpdateAt(idx, func(conn *WebSocketConnection) {
-				conn.SentCount++
-				ctx.events.AppendWSFrame(conn.URL, "sent", e.Response)
-			})
-		}
+		ctx.events.UpdateWSConnection(string(e.RequestID), func(conn *WebSocketConnection) {
+			conn.SentCount++
+			ctx.events.AppendWSFrame(conn.URL, "sent", e.Response)
+		})
 		ctx.stateLock.Unlock()
 	}, func(e *proto.NetworkWebSocketFrameReceived) {
 		ctx.stateLock.Lock()
-		if idx, ok := ctx.events.wsConnIndex[string(e.RequestID)]; ok {
-			ctx.events.wsConnections.UpdateAt(idx, func(conn *WebSocketConnection) {
-				conn.ReceivedCount++
-				ctx.events.AppendWSFrame(conn.URL, "received", e.Response)
-			})
-		}
+		ctx.events.UpdateWSConnection(string(e.RequestID), func(conn *WebSocketConnection) {
+			conn.ReceivedCount++
+			ctx.events.AppendWSFrame(conn.URL, "received", e.Response)
+		})
 		ctx.stateLock.Unlock()
 	}, func(e *proto.NetworkWebSocketClosed) {
 		ctx.stateLock.Lock()
-		if idx, ok := ctx.events.wsConnIndex[string(e.RequestID)]; ok {
-			ctx.events.wsConnections.UpdateAt(idx, func(conn *WebSocketConnection) {
-				conn.Closed = true
-			})
-		}
+		ctx.events.UpdateWSConnection(string(e.RequestID), func(conn *WebSocketConnection) {
+			conn.Closed = true
+		})
 		ctx.stateLock.Unlock()
 	})()
 

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -344,6 +344,27 @@ func TestApplyStealthHeaders_PreservesExistingHeaders(t *testing.T) {
 	}
 }
 
+func TestApplyStealthHeaders_CaseInsensitiveLookup(t *testing.T) {
+	ctx := newTestContext()
+	ctx.config.Stealth = true
+
+	// Lower-case header keys should still prevent stealth from adding duplicates.
+	existing := map[string]string{
+		"user-agent": "CustomAgent/1.0",
+		"sec-ch-ua":  `"Custom";v="1"`,
+	}
+	headers := ctx.applyStealthHeaders(existing)
+	if len(headers) != 2 {
+		t.Errorf("expected 2 headers, got %d: %v", len(headers), headers)
+	}
+	if headers["user-agent"] != "CustomAgent/1.0" {
+		t.Errorf("user-agent was overwritten: %q", headers["user-agent"])
+	}
+	if headers["sec-ch-ua"] != `"Custom";v="1"` {
+		t.Errorf("sec-ch-ua was overwritten: %q", headers["sec-ch-ua"])
+	}
+}
+
 func TestReconfigure_Stealth(t *testing.T) {
 	ctx := newTestContext()
 	ctx.config.Stealth = false

--- a/types/event_collector.go
+++ b/types/event_collector.go
@@ -18,9 +18,9 @@ const (
 	maxWSFrames = 10000
 )
 
-// EventCollector owns the ring buffers for console messages, network requests,
+// eventCollector owns the ring buffers for console messages, network requests,
 // and WebSocket tracking. All methods assume the caller holds Context.stateLock.
-type EventCollector struct {
+type eventCollector struct {
 	consoleMessages *RingBuffer[ConsoleMessage]
 	networkRequests *RingBuffer[NetworkRequest]
 	// pendingRequests tracks in-flight requests by ID for response correlation.
@@ -33,9 +33,9 @@ type EventCollector struct {
 	wsFrames      *RingBuffer[WebSocketFrame]
 }
 
-// NewEventCollector creates an EventCollector with default-sized ring buffers.
-func NewEventCollector() *EventCollector {
-	return &EventCollector{
+// newEventCollector creates an eventCollector with default-sized ring buffers.
+func newEventCollector() *eventCollector {
+	return &eventCollector{
 		consoleMessages: NewRingBuffer[ConsoleMessage](maxConsoleMessages),
 		networkRequests: NewRingBuffer[NetworkRequest](maxNetworkRequests),
 		wsConnections:   NewRingBuffer[WebSocketConnection](maxWSConnections),
@@ -44,13 +44,13 @@ func NewEventCollector() *EventCollector {
 }
 
 // AddConsoleMessage records a console message. Must be called with stateLock held.
-func (ec *EventCollector) AddConsoleMessage(msg ConsoleMessage) {
+func (ec *eventCollector) AddConsoleMessage(msg ConsoleMessage) {
 	ec.consoleMessages.Add(msg)
 }
 
 // AddNetworkRequest records a new outgoing request and tracks it as pending.
 // Must be called with stateLock held.
-func (ec *EventCollector) AddNetworkRequest(req NetworkRequest) {
+func (ec *eventCollector) AddNetworkRequest(req NetworkRequest) {
 	if ec.pendingRequests == nil {
 		ec.pendingRequests = make(map[string]int)
 	}
@@ -60,7 +60,7 @@ func (ec *EventCollector) AddNetworkRequest(req NetworkRequest) {
 
 // CompleteNetworkRequest updates a pending request with its response status and type.
 // Must be called with stateLock held.
-func (ec *EventCollector) CompleteNetworkRequest(requestID string, status int, typ string) {
+func (ec *eventCollector) CompleteNetworkRequest(requestID string, status int, typ string) {
 	if idx, ok := ec.pendingRequests[requestID]; ok {
 		ec.networkRequests.UpdateAt(idx, func(req *NetworkRequest) {
 			req.Status = status
@@ -71,7 +71,7 @@ func (ec *EventCollector) CompleteNetworkRequest(requestID string, status int, t
 }
 
 // AddWSConnection records a new WebSocket connection. Must be called with stateLock held.
-func (ec *EventCollector) AddWSConnection(conn WebSocketConnection) {
+func (ec *eventCollector) AddWSConnection(conn WebSocketConnection) {
 	if ec.wsConnIndex == nil {
 		ec.wsConnIndex = make(map[string]int)
 	}
@@ -81,7 +81,7 @@ func (ec *EventCollector) AddWSConnection(conn WebSocketConnection) {
 
 // UpdateWSConnection calls fn on the WebSocket connection identified by requestID.
 // Must be called with stateLock held.
-func (ec *EventCollector) UpdateWSConnection(requestID string, fn func(*WebSocketConnection)) {
+func (ec *eventCollector) UpdateWSConnection(requestID string, fn func(*WebSocketConnection)) {
 	if idx, ok := ec.wsConnIndex[requestID]; ok {
 		ec.wsConnections.UpdateAt(idx, fn)
 	}
@@ -89,7 +89,7 @@ func (ec *EventCollector) UpdateWSConnection(requestID string, fn func(*WebSocke
 
 // AppendWSFrame adds a WebSocket frame to the ring buffer.
 // Must be called with stateLock held.
-func (ec *EventCollector) AppendWSFrame(url, direction string, frame *proto.NetworkWebSocketFrame) {
+func (ec *eventCollector) AppendWSFrame(url, direction string, frame *proto.NetworkWebSocketFrame) {
 	ec.wsFrames.Add(WebSocketFrame{
 		URL:         url,
 		Direction:   direction,
@@ -101,7 +101,7 @@ func (ec *EventCollector) AppendWSFrame(url, direction string, frame *proto.Netw
 // ConsoleMessages returns captured console messages, optionally filtered by level.
 // If clear is true, the buffer is emptied after returning.
 // Must be called with stateLock held.
-func (ec *EventCollector) ConsoleMessages(filterLevel string, clear bool) []ConsoleMessage {
+func (ec *eventCollector) ConsoleMessages(filterLevel string, clear bool) []ConsoleMessage {
 	all := ec.consoleMessages.Slice()
 	result := filterSlice(all, func(msg ConsoleMessage) bool {
 		return filterLevel == "" || msg.Level == filterLevel
@@ -128,7 +128,7 @@ func (ec *EventCollector) ConsoleMessages(filterLevel string, clear bool) []Cons
 // NetworkRequests returns captured network requests, optionally filtered by URL pattern and method.
 // If clear is true, the buffer is emptied after returning.
 // Must be called with stateLock held.
-func (ec *EventCollector) NetworkRequests(filterURL, filterMethod string, clear bool) []NetworkRequest {
+func (ec *eventCollector) NetworkRequests(filterURL, filterMethod string, clear bool) []NetworkRequest {
 	result := filterSlice(ec.networkRequests.Slice(), func(req NetworkRequest) bool {
 		if filterURL != "" && !strings.Contains(req.URL, filterURL) {
 			return false
@@ -149,7 +149,7 @@ func (ec *EventCollector) NetworkRequests(filterURL, filterMethod string, clear 
 
 // GetRequestID returns the CDP request ID for a network request at the given index.
 // Must be called with stateLock held.
-func (ec *EventCollector) GetRequestID(index int) (string, error) {
+func (ec *eventCollector) GetRequestID(index int) (string, error) {
 	all := ec.networkRequests.Slice()
 	if len(all) == 0 {
 		return "", fmt.Errorf("no network requests captured")
@@ -162,7 +162,7 @@ func (ec *EventCollector) GetRequestID(index int) (string, error) {
 
 // WebSocketConnections returns tracked WebSocket connections, optionally filtered by URL.
 // Must be called with stateLock held.
-func (ec *EventCollector) WebSocketConnections(urlFilter string) []WebSocketConnection {
+func (ec *eventCollector) WebSocketConnections(urlFilter string) []WebSocketConnection {
 	return filterSlice(ec.wsConnections.Slice(), func(conn WebSocketConnection) bool {
 		return urlFilter == "" || strings.Contains(conn.URL, urlFilter)
 	})
@@ -170,7 +170,7 @@ func (ec *EventCollector) WebSocketConnections(urlFilter string) []WebSocketConn
 
 // WebSocketFrames returns captured WebSocket frames, optionally filtered by URL and direction.
 // Must be called with stateLock held.
-func (ec *EventCollector) WebSocketFrames(urlFilter, direction string) []WebSocketFrame {
+func (ec *eventCollector) WebSocketFrames(urlFilter, direction string) []WebSocketFrame {
 	return filterSlice(ec.wsFrames.Slice(), func(f WebSocketFrame) bool {
 		if urlFilter != "" && !strings.Contains(f.URL, urlFilter) {
 			return false
@@ -184,7 +184,7 @@ func (ec *EventCollector) WebSocketFrames(urlFilter, direction string) []WebSock
 
 // ClearWebSocketData clears all WebSocket connections and frames.
 // Must be called with stateLock held.
-func (ec *EventCollector) ClearWebSocketData() {
+func (ec *eventCollector) ClearWebSocketData() {
 	ec.wsConnections.Clear()
 	ec.wsConnIndex = nil
 	ec.wsFrames.Clear()

--- a/types/network_interceptor.go
+++ b/types/network_interceptor.go
@@ -4,18 +4,18 @@ import (
 	"github.com/go-rod/rod/lib/proto"
 )
 
-// NetworkInterceptor owns the state for CDP request interception (Fetch domain).
+// networkInterceptor owns the state for CDP request interception (Fetch domain).
 // All methods assume the caller holds Context.stateLock.
-type NetworkInterceptor struct {
+type networkInterceptor struct {
 	rules   []InterceptRule
 	enabled bool
 	// cancel cancels the EachEvent goroutine started by interceptEnable.
 	cancel func()
 }
 
-// NewNetworkInterceptor creates a NetworkInterceptor with no rules and interception disabled.
-func NewNetworkInterceptor() *NetworkInterceptor {
-	return &NetworkInterceptor{}
+// newNetworkInterceptor creates a networkInterceptor with no rules and interception disabled.
+func newNetworkInterceptor() *networkInterceptor {
+	return &networkInterceptor{}
 }
 
 // InterceptRule defines a rule for how to handle an intercepted request.
@@ -30,14 +30,14 @@ type InterceptRule struct {
 
 // Enabled returns whether request interception is currently enabled.
 // Must be called with stateLock held.
-func (ni *NetworkInterceptor) Enabled() bool {
+func (ni *networkInterceptor) Enabled() bool {
 	return ni.enabled
 }
 
 // SetEnabled sets whether interception is enabled.
 // When disabling, any existing intercept listener goroutine is cancelled and rules are cleared.
 // Must be called with stateLock held.
-func (ni *NetworkInterceptor) SetEnabled(enabled bool) {
+func (ni *networkInterceptor) SetEnabled(enabled bool) {
 	ni.enabled = enabled
 	if !enabled {
 		ni.rules = nil
@@ -51,7 +51,7 @@ func (ni *NetworkInterceptor) SetEnabled(enabled bool) {
 // SetCancel stores the cancel function for the intercept EachEvent goroutine.
 // Any prior listener is cancelled before replacing.
 // Must be called with stateLock held.
-func (ni *NetworkInterceptor) SetCancel(cancel func()) {
+func (ni *networkInterceptor) SetCancel(cancel func()) {
 	if ni.cancel != nil {
 		ni.cancel()
 	}
@@ -60,7 +60,7 @@ func (ni *NetworkInterceptor) SetCancel(cancel func()) {
 
 // Cancel cancels the intercept listener goroutine if one is running, and
 // clears the cancel function. Must be called with stateLock held.
-func (ni *NetworkInterceptor) Cancel() {
+func (ni *networkInterceptor) Cancel() {
 	if ni.cancel != nil {
 		ni.cancel()
 		ni.cancel = nil
@@ -69,13 +69,13 @@ func (ni *NetworkInterceptor) Cancel() {
 
 // AddRule appends an interception rule.
 // Must be called with stateLock held.
-func (ni *NetworkInterceptor) AddRule(rule InterceptRule) {
+func (ni *networkInterceptor) AddRule(rule InterceptRule) {
 	ni.rules = append(ni.rules, rule)
 }
 
 // Rules returns a copy of the current interception rules.
 // Must be called with stateLock held.
-func (ni *NetworkInterceptor) Rules() []InterceptRule {
+func (ni *networkInterceptor) Rules() []InterceptRule {
 	rules := make([]InterceptRule, len(ni.rules))
 	copy(rules, ni.rules)
 	return rules

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -211,6 +211,12 @@ func (s *Snapshot) walkIframeNode(node *yaml.Node, frame *rod.Page) *yaml.Node {
 	}
 
 	ref := matches[1]
+	// Strip optional frame prefix (e.g. "f1e42" → "e42") that adjustFrameRef
+	// may have added before tryExpandIframe is called. The DOM element still
+	// has the original unprefixed ref.
+	if fm := iframeRefPattern.FindStringSubmatch(ref); len(fm) > 0 {
+		ref = fm[2]
+	}
 	fallback := &yaml.Node{Kind: yaml.ScalarNode, Value: "<could not capture iframe snapshot>"}
 	pairNode := &yaml.Node{
 		Kind:    yaml.MappingNode,


### PR DESCRIPTION
## Summary

Addresses unresolved Copilot review comments across recent PRs:

- **Fix nested iframe ref resolution** (#260): `walkIframeNode` now strips frame prefix (e.g. `f1e42` -> `e42`) before querying the DOM, fixing lookup failures on nested iframes
- **Fix case-insensitive header check** (#261): `applyStealthHeaders` uses case-insensitive lookup to prevent duplicate headers when user-configured keys differ in casing
- **EventCollector encapsulation** (#263): `attachEventListeners` now uses `UpdateWSConnection()` API instead of reaching into internal fields
- **Unexport internal types** (#263): `eventCollector` and `networkInterceptor` are only used within the `types` package -- unexported to prevent external misuse
- **Standardize EXPERIMENTAL markers** (#262): Consistent `[EXPERIMENTAL]` format across tool descriptions, config comments, and log messages; stealth log downgraded from Warnf to Infof

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New test `TestApplyStealthHeaders_CaseInsensitiveLookup` validates case-insensitive header deduplication
- [ ] CI green