### PR TITLE
fix: security + reliability — SQL injection, TOCTOU race, DRY registration

### DIFF
--- a/server.go
+++ b/server.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"context"
+
 	"github.com/charmbracelet/log"
+	"github.com/mark3labs/mcp-go/server"
+
 	"github.com/aliwatters/rod-mcp/tools"
 	"github.com/aliwatters/rod-mcp/types"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
 )
 
 type Server struct {
@@ -23,21 +24,20 @@ func NewServer(stdCtx context.Context, cfg types.Config) *Server {
 	}
 	switch ctx.CurrentMode() {
 	case types.Text:
-		ser.registerTools(tools.TextTools, tools.TextToolHandlers)
+		ser.registerTools(tools.TextRegistrations)
 	case types.Vision:
-		ser.registerTools(tools.VisionTools, tools.VisionCombinedHandlers)
+		ser.registerTools(tools.VisionRegistrations)
 	}
 	return ser
 }
 
-func (s *Server) registerTools(mcpTools []mcp.Tool, handlers map[string]tools.ToolHandler) *Server {
-	for _, mt := range mcpTools {
-		if handlerFunc, ok := handlers[mt.Name]; ok {
-			log.Debugf("register tool: %s", mt.Name)
-			s.mcpServer.AddTool(mt, handlerFunc(s.ctx))
-		} else {
-			log.Warnf("tool %q defined but no handler registered — check tool name", mt.Name)
-		}
+// registerTools registers all tools from the given Registrations into the MCP server.
+// Each Registration is self-contained — it pairs a tool definition with its handler,
+// so there is no risk of a tool being registered without a handler.
+func (s *Server) registerTools(regs tools.Registrations) *Server {
+	for _, reg := range regs {
+		log.Debugf("register tool: %s", reg.Tool.Name)
+		s.mcpServer.AddTool(reg.Tool, reg.Handler(s.ctx))
 	}
 	return s
 }

--- a/tools/args.go
+++ b/tools/args.go
@@ -28,6 +28,19 @@ func getFloatArg(args map[string]interface{}, key string) (float64, error) {
 	return f, nil
 }
 
+// getBoolArg extracts a required bool argument from the MCP request.
+func getBoolArg(args map[string]interface{}, key string) (bool, error) {
+	v, ok := args[key]
+	if !ok {
+		return false, fmt.Errorf("missing required argument: %s", key)
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("argument %s must be a boolean, got %T", key, v)
+	}
+	return b, nil
+}
+
 // getOptionalStringArg extracts an optional string argument, returning "" if not present.
 func getOptionalStringArg(args map[string]interface{}, key string) string {
 	v, _ := args[key].(string)
@@ -48,4 +61,22 @@ func getOptionalBoolArg(args map[string]interface{}, key string, fallback bool) 
 		return v
 	}
 	return fallback
+}
+
+// getOptionalBoolPtr extracts an optional bool argument as a pointer, returning nil if not present.
+// Use this when you need to distinguish "not provided" from false (e.g. for Reconfigure).
+func getOptionalBoolPtr(args map[string]interface{}, key string) *bool {
+	if v, ok := args[key].(bool); ok {
+		return &v
+	}
+	return nil
+}
+
+// getOptionalStringPtr extracts an optional string argument as a pointer, returning nil if not present.
+// Use this when you need to distinguish "not provided" from "" (e.g. for Reconfigure).
+func getOptionalStringPtr(args map[string]interface{}, key string) *string {
+	if v, ok := args[key].(string); ok {
+		return &v
+	}
+	return nil
 }

--- a/tools/args_test.go
+++ b/tools/args_test.go
@@ -114,3 +114,68 @@ func TestGetOptionalBoolArg(t *testing.T) {
 		t.Errorf("getOptionalBoolArg(name) = %v, want false (wrong type)", got)
 	}
 }
+
+func TestGetBoolArg(t *testing.T) {
+	args := map[string]interface{}{
+		"flag":  true,
+		"count": 42.0,
+	}
+
+	tests := []struct {
+		name    string
+		key     string
+		want    bool
+		wantErr bool
+	}{
+		{"present bool", "flag", true, false},
+		{"missing key", "missing", false, true},
+		{"wrong type", "count", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getBoolArg(args, tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getBoolArg(%q) error = %v, wantErr %v", tt.key, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getBoolArg(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetOptionalBoolPtr(t *testing.T) {
+	args := map[string]interface{}{
+		"flag":  true,
+		"count": 42.0,
+	}
+
+	if got := getOptionalBoolPtr(args, "flag"); got == nil || *got != true {
+		t.Errorf("getOptionalBoolPtr(flag): want *true, got %v", got)
+	}
+	if got := getOptionalBoolPtr(args, "missing"); got != nil {
+		t.Errorf("getOptionalBoolPtr(missing): want nil, got %v", got)
+	}
+	if got := getOptionalBoolPtr(args, "count"); got != nil {
+		t.Errorf("getOptionalBoolPtr(count): want nil for wrong type, got %v", got)
+	}
+}
+
+func TestGetOptionalStringPtr(t *testing.T) {
+	args := map[string]interface{}{
+		"name":  "hello",
+		"count": 42.0,
+	}
+
+	if got := getOptionalStringPtr(args, "name"); got == nil || *got != "hello" {
+		t.Errorf("getOptionalStringPtr(name): want *%q, got %v", "hello", got)
+	}
+	if got := getOptionalStringPtr(args, "missing"); got != nil {
+		t.Errorf("getOptionalStringPtr(missing): want nil, got %v", got)
+	}
+	if got := getOptionalStringPtr(args, "count"); got != nil {
+		t.Errorf("getOptionalStringPtr(count): want nil for wrong type, got %v", got)
+	}
+}

--- a/tools/common_test.go
+++ b/tools/common_test.go
@@ -289,6 +289,52 @@ func TestEvaluateToolDefinition(t *testing.T) {
 	}
 }
 
+// TestRegistrationsDRY verifies that the Registrations type correctly derives
+// both Tools() slices and Handlers() maps, so the two structures cannot drift.
+func TestRegistrationsDRY(t *testing.T) {
+	// Every tool in CommonRegistrations must appear in CommonTools with a handler.
+	for _, reg := range CommonRegistrations {
+		name := reg.Tool.Name
+
+		foundTool := false
+		for _, t2 := range CommonTools {
+			if t2.Name == name {
+				foundTool = true
+				break
+			}
+		}
+		if !foundTool {
+			t.Errorf("CommonRegistrations entry %q missing from CommonTools", name)
+		}
+
+		if _, ok := CommonToolHandlers[name]; !ok {
+			t.Errorf("CommonRegistrations entry %q missing from CommonToolHandlers", name)
+		}
+	}
+
+	// Tools() and Handlers() must have the same count as CommonRegistrations.
+	if len(CommonTools) != len(CommonRegistrations) {
+		t.Errorf("CommonTools len = %d, want %d (same as CommonRegistrations)", len(CommonTools), len(CommonRegistrations))
+	}
+	if len(CommonToolHandlers) != len(CommonRegistrations) {
+		t.Errorf("CommonToolHandlers len = %d, want %d (same as CommonRegistrations)", len(CommonToolHandlers), len(CommonRegistrations))
+	}
+}
+
+func TestTextRegistrationsComplete(t *testing.T) {
+	// TextRegistrations must contain all common + all snapshot tools.
+	wantLen := len(CommonRegistrations) + len(SnapshotRegistrations)
+	if len(TextRegistrations) != wantLen {
+		t.Errorf("TextRegistrations len = %d, want %d", len(TextRegistrations), wantLen)
+	}
+	handlers := TextRegistrations.Handlers()
+	for _, reg := range TextRegistrations {
+		if _, ok := handlers[reg.Tool.Name]; !ok {
+			t.Errorf("TextRegistrations entry %q has no handler in derived map", reg.Tool.Name)
+		}
+	}
+}
+
 func TestNavigationUsesToolKey(t *testing.T) {
 	if Navigation.Name != NavigationToolKey {
 		t.Errorf("Navigation tool name = %q, want %q (should use NavigationToolKey constant)", Navigation.Name, NavigationToolKey)

--- a/tools/configure.go
+++ b/tools/configure.go
@@ -24,20 +24,9 @@ var ConfigureHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := request.GetArguments()
 
-		var headless *bool
-		if v, ok := args["headless"].(bool); ok {
-			headless = &v
-		}
-
-		var cdpEndpoint *string
-		if v, ok := args["cdp_endpoint"].(string); ok {
-			cdpEndpoint = &v
-		}
-
-		var stealth *bool
-		if v, ok := args["stealth"].(bool); ok {
-			stealth = &v
-		}
+		headless := getOptionalBoolPtr(args, "headless")
+		cdpEndpoint := getOptionalStringPtr(args, "cdp_endpoint")
+		stealth := getOptionalBoolPtr(args, "stealth")
 
 		if err := rodCtx.Reconfigure(headless, cdpEndpoint, stealth); err != nil {
 			return toolErr("configure browser", err)

--- a/tools/cookies.go
+++ b/tools/cookies.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
+	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -53,186 +54,204 @@ var (
 
 			switch action {
 			case "get":
-				var urls []string
-				if u := getOptionalStringArg(args, "url"); u != "" {
-					urls = []string{u}
-				}
-				resp, err := proto.NetworkGetCookies{Urls: urls}.Call(page)
-				if err != nil {
-					return toolErr("get cookies", err)
-				}
-				if len(resp.Cookies) == 0 {
-					return mcp.NewToolResultText("No cookies found"), nil
-				}
-
-				type cookieInfo struct {
-					Name     string `json:"name"`
-					Value    string `json:"value"`
-					Domain   string `json:"domain"`
-					Path     string `json:"path"`
-					Secure   bool   `json:"secure,omitempty"`
-					HTTPOnly bool   `json:"httpOnly,omitempty"`
-					SameSite string `json:"sameSite,omitempty"`
-					Session  bool   `json:"session,omitempty"`
-				}
-				cookies := make([]cookieInfo, 0, len(resp.Cookies))
-				for _, c := range resp.Cookies {
-					cookies = append(cookies, cookieInfo{
-						Name:     c.Name,
-						Value:    c.Value,
-						Domain:   c.Domain,
-						Path:     c.Path,
-						Secure:   c.Secure,
-						HTTPOnly: c.HTTPOnly,
-						SameSite: string(c.SameSite),
-						Session:  c.Session,
-					})
-				}
-				out, err := json.MarshalIndent(cookies, "", "  ")
-				if err != nil {
-					return toolErr("format cookies", err)
-				}
-				return mcp.NewToolResultText(fmt.Sprintf("%d cookies:\n%s", len(cookies), string(out))), nil
-
+				return cookiesGet(page, args)
 			case "set":
-				name, err := getStringArg(args, "name")
-				if err != nil {
-					return toolErr("set cookie", err)
-				}
-				value, err := getStringArg(args, "value")
-				if err != nil {
-					return toolErr("set cookie", err)
-				}
-				cookie := proto.NetworkSetCookie{
-					Name:     name,
-					Value:    value,
-					URL:      getOptionalStringArg(args, "url"),
-					Domain:   getOptionalStringArg(args, "domain"),
-					Path:     getOptionalStringArg(args, "path"),
-					Secure:   getOptionalBoolArg(args, "secure", false),
-					HTTPOnly: getOptionalBoolArg(args, "httpOnly", false),
-				}
-				// Default to current page URL if neither url nor domain is specified
-				if cookie.URL == "" && cookie.Domain == "" {
-					info, err := page.Info()
-					if err == nil {
-						cookie.URL = info.URL
-					}
-				}
-				if ss := getOptionalStringArg(args, "sameSite"); ss != "" {
-					cookie.SameSite = proto.NetworkCookieSameSite(ss)
-				}
-				_, err = cookie.Call(page)
-				if err != nil {
-					return toolErr(fmt.Sprintf("set cookie %q", name), err)
-				}
-				return mcp.NewToolResultText(fmt.Sprintf("Cookie %q set successfully", name)), nil
-
+				return cookiesSet(page, args)
 			case "delete":
-				name, err := getStringArg(args, "name")
-				if err != nil {
-					return toolErr("delete cookie", err)
-				}
-				delReq := proto.NetworkDeleteCookies{
-					Name:   name,
-					URL:    getOptionalStringArg(args, "url"),
-					Domain: getOptionalStringArg(args, "domain"),
-					Path:   getOptionalStringArg(args, "path"),
-				}
-				// Default to current page URL if no scope is specified
-				if delReq.URL == "" && delReq.Domain == "" {
-					info, err := page.Info()
-					if err == nil {
-						delReq.URL = info.URL
-					}
-				}
-				err = delReq.Call(page)
-				if err != nil {
-					return toolErr(fmt.Sprintf("delete cookie %q", name), err)
-				}
-				return mcp.NewToolResultText(fmt.Sprintf("Cookie %q deleted successfully", name)), nil
-
+				return cookiesDelete(page, args)
 			case "clear":
-				err := proto.NetworkClearBrowserCookies{}.Call(page)
-				if err != nil {
-					return toolErr("clear cookies", err)
-				}
-				return mcp.NewToolResultText("All cookies cleared"), nil
-
+				return cookiesClear(page)
 			case "save":
-				savePath, err := getCookieFilePath(rodCtx, args)
-				if err != nil {
-					return toolErr("save cookies", err)
-				}
-
-				resp, err := proto.NetworkGetAllCookies{}.Call(page)
-				if err != nil {
-					return toolErr("save cookies", err)
-				}
-				data, err := json.MarshalIndent(resp.Cookies, "", "  ")
-				if err != nil {
-					return toolErr("save cookies", err)
-				}
-				if err := os.WriteFile(savePath, data, 0o644); err != nil {
-					return toolErr("save cookies", fmt.Errorf("write %s: %w", savePath, err))
-				}
-				return mcp.NewToolResultText(fmt.Sprintf("Saved %d cookies to %s", len(resp.Cookies), savePath)), nil
-
+				return cookiesSave(rodCtx, page, args)
 			case "restore":
-				restorePath, err := getCookieFilePath(rodCtx, args)
-				if err != nil {
-					return toolErr("restore cookies", err)
-				}
-
-				data, err := os.ReadFile(restorePath)
-				if err != nil {
-					return toolErr("restore cookies", fmt.Errorf("read %s: %w", restorePath, err))
-				}
-				var cookies []*proto.NetworkCookie
-				if err := json.Unmarshal(data, &cookies); err != nil {
-					return toolErr("restore cookies", fmt.Errorf("parse %s: %w", restorePath, err))
-				}
-
-				now := proto.TimeSinceEpoch(time.Now().Unix())
-				var restored, skipped int
-				for _, c := range cookies {
-					// Skip expired cookies
-					if c.Expires > 0 && c.Expires < now {
-						log.Debugf("cookie %q expired, skipping", c.Name)
-						skipped++
-						continue
-					}
-					setCookie := proto.NetworkSetCookie{
-						Name:     c.Name,
-						Value:    c.Value,
-						Domain:   c.Domain,
-						Path:     c.Path,
-						Secure:   c.Secure,
-						HTTPOnly: c.HTTPOnly,
-						SameSite: c.SameSite,
-					}
-					if c.Expires > 0 {
-						setCookie.Expires = c.Expires
-					}
-					if _, err := setCookie.Call(page); err != nil {
-						log.Warnf("failed to restore cookie %q: %s", c.Name, err)
-						continue
-					}
-					restored++
-				}
-				msg := fmt.Sprintf("Restored %d cookies from %s", restored, restorePath)
-				if skipped > 0 {
-					msg += fmt.Sprintf(" (%d expired cookies skipped)", skipped)
-				}
-				return mcp.NewToolResultText(msg), nil
-
-					default:
+				return cookiesRestore(rodCtx, page, args)
+			default:
 				return nil, fmt.Errorf("invalid action %q: must be get, set, delete, clear, save, or restore", action)
 			}
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
 )
+
+// cookieInfo is the JSON-serialisable view of a cookie returned by the "get" action.
+type cookieInfo struct {
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	Domain   string `json:"domain"`
+	Path     string `json:"path"`
+	Secure   bool   `json:"secure,omitempty"`
+	HTTPOnly bool   `json:"httpOnly,omitempty"`
+	SameSite string `json:"sameSite,omitempty"`
+	Session  bool   `json:"session,omitempty"`
+}
+
+// cookiesGet handles the "get" action: list cookies, optionally filtered by URL.
+func cookiesGet(page *rod.Page, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	var urls []string
+	if u := getOptionalStringArg(args, "url"); u != "" {
+		urls = []string{u}
+	}
+	resp, err := proto.NetworkGetCookies{Urls: urls}.Call(page)
+	if err != nil {
+		return toolErr("get cookies", err)
+	}
+	if len(resp.Cookies) == 0 {
+		return mcp.NewToolResultText("No cookies found"), nil
+	}
+	cookies := make([]cookieInfo, 0, len(resp.Cookies))
+	for _, c := range resp.Cookies {
+		cookies = append(cookies, cookieInfo{
+			Name:     c.Name,
+			Value:    c.Value,
+			Domain:   c.Domain,
+			Path:     c.Path,
+			Secure:   c.Secure,
+			HTTPOnly: c.HTTPOnly,
+			SameSite: string(c.SameSite),
+			Session:  c.Session,
+		})
+	}
+	out, err := json.MarshalIndent(cookies, "", "  ")
+	if err != nil {
+		return toolErr("format cookies", err)
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("%d cookies:\n%s", len(cookies), string(out))), nil
+}
+
+// cookiesSet handles the "set" action: create or update a cookie.
+func cookiesSet(page *rod.Page, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	name, err := getStringArg(args, "name")
+	if err != nil {
+		return toolErr("set cookie", err)
+	}
+	value, err := getStringArg(args, "value")
+	if err != nil {
+		return toolErr("set cookie", err)
+	}
+	cookie := proto.NetworkSetCookie{
+		Name:     name,
+		Value:    value,
+		URL:      getOptionalStringArg(args, "url"),
+		Domain:   getOptionalStringArg(args, "domain"),
+		Path:     getOptionalStringArg(args, "path"),
+		Secure:   getOptionalBoolArg(args, "secure", false),
+		HTTPOnly: getOptionalBoolArg(args, "httpOnly", false),
+	}
+	// Default to current page URL if neither url nor domain is specified.
+	if cookie.URL == "" && cookie.Domain == "" {
+		if info, err := page.Info(); err == nil {
+			cookie.URL = info.URL
+		}
+	}
+	if ss := getOptionalStringArg(args, "sameSite"); ss != "" {
+		cookie.SameSite = proto.NetworkCookieSameSite(ss)
+	}
+	if _, err = cookie.Call(page); err != nil {
+		return toolErr(fmt.Sprintf("set cookie %q", name), err)
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("Cookie %q set successfully", name)), nil
+}
+
+// cookiesDelete handles the "delete" action: remove a named cookie.
+func cookiesDelete(page *rod.Page, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	name, err := getStringArg(args, "name")
+	if err != nil {
+		return toolErr("delete cookie", err)
+	}
+	delReq := proto.NetworkDeleteCookies{
+		Name:   name,
+		URL:    getOptionalStringArg(args, "url"),
+		Domain: getOptionalStringArg(args, "domain"),
+		Path:   getOptionalStringArg(args, "path"),
+	}
+	// Default to current page URL if no scope is specified.
+	if delReq.URL == "" && delReq.Domain == "" {
+		if info, err := page.Info(); err == nil {
+			delReq.URL = info.URL
+		}
+	}
+	if err = delReq.Call(page); err != nil {
+		return toolErr(fmt.Sprintf("delete cookie %q", name), err)
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("Cookie %q deleted successfully", name)), nil
+}
+
+// cookiesClear handles the "clear" action: delete all browser cookies.
+func cookiesClear(page *rod.Page) (*mcp.CallToolResult, error) {
+	clear := proto.NetworkClearBrowserCookies{}
+	if err := clear.Call(page); err != nil {
+		return toolErr("clear cookies", err)
+	}
+	return mcp.NewToolResultText("All cookies cleared"), nil
+}
+
+// cookiesSave handles the "save" action: write all cookies to a JSON file.
+func cookiesSave(rodCtx *types.Context, page *rod.Page, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	savePath, err := getCookieFilePath(rodCtx, args)
+	if err != nil {
+		return toolErr("save cookies", err)
+	}
+	resp, err := proto.NetworkGetAllCookies{}.Call(page)
+	if err != nil {
+		return toolErr("save cookies", err)
+	}
+	data, err := json.MarshalIndent(resp.Cookies, "", "  ")
+	if err != nil {
+		return toolErr("save cookies", err)
+	}
+	if err := os.WriteFile(savePath, data, 0o644); err != nil {
+		return toolErr("save cookies", fmt.Errorf("write %s: %w", savePath, err))
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("Saved %d cookies to %s", len(resp.Cookies), savePath)), nil
+}
+
+// cookiesRestore handles the "restore" action: load cookies from a JSON file and inject them.
+func cookiesRestore(rodCtx *types.Context, page *rod.Page, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	restorePath, err := getCookieFilePath(rodCtx, args)
+	if err != nil {
+		return toolErr("restore cookies", err)
+	}
+	data, err := os.ReadFile(restorePath)
+	if err != nil {
+		return toolErr("restore cookies", fmt.Errorf("read %s: %w", restorePath, err))
+	}
+	var cookies []*proto.NetworkCookie
+	if err := json.Unmarshal(data, &cookies); err != nil {
+		return toolErr("restore cookies", fmt.Errorf("parse %s: %w", restorePath, err))
+	}
+
+	now := proto.TimeSinceEpoch(time.Now().Unix())
+	var restored, skipped int
+	for _, c := range cookies {
+		if c.Expires > 0 && c.Expires < now {
+			log.Debugf("cookie %q expired, skipping", c.Name)
+			skipped++
+			continue
+		}
+		setCookie := proto.NetworkSetCookie{
+			Name:     c.Name,
+			Value:    c.Value,
+			Domain:   c.Domain,
+			Path:     c.Path,
+			Secure:   c.Secure,
+			HTTPOnly: c.HTTPOnly,
+			SameSite: c.SameSite,
+		}
+		if c.Expires > 0 {
+			setCookie.Expires = c.Expires
+		}
+		if _, err := setCookie.Call(page); err != nil {
+			log.Warnf("failed to restore cookie %q: %s", c.Name, err)
+			continue
+		}
+		restored++
+	}
+	msg := fmt.Sprintf("Restored %d cookies from %s", restored, restorePath)
+	if skipped > 0 {
+		msg += fmt.Sprintf(" (%d expired cookies skipped)", skipped)
+	}
+	return mcp.NewToolResultText(msg), nil
+}
 
 // getCookieFilePath resolves and validates the file path for cookie save/restore.
 // Restricts paths to be within the output directory to prevent path traversal.

--- a/tools/geolocation.go
+++ b/tools/geolocation.go
@@ -39,8 +39,8 @@ var (
 
 			// Clear override if no coordinates provided
 			if !hasLat && !hasLng {
-				clearErr := proto.EmulationSetGeolocationOverride{}.Call(page)
-				if clearErr != nil {
+				clear := proto.EmulationSetGeolocationOverride{}
+				if clearErr := clear.Call(page); clearErr != nil {
 					return toolErr("clear geolocation", clearErr)
 				}
 				return mcp.NewToolResultText("Geolocation override cleared"), nil
@@ -50,8 +50,14 @@ var (
 				return toolErr("geolocation", fmt.Errorf("both 'latitude' and 'longitude' are required"))
 			}
 
-			lat := args["latitude"].(float64)
-			lng := args["longitude"].(float64)
+			lat, err := getFloatArg(args, "latitude")
+			if err != nil {
+				return toolErr("geolocation", err)
+			}
+			lng, err := getFloatArg(args, "longitude")
+			if err != nil {
+				return toolErr("geolocation", err)
+			}
 			accuracy := getOptionalFloatArg(args, "accuracy", 1)
 
 			if lat < -90 || lat > 90 {

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -204,19 +204,18 @@ var (
 	}
 )
 
+// SnapshotRegistrations is the single source of truth for text-mode (snapshot)
+// tool definitions and their handlers.
+var SnapshotRegistrations = Registrations{
+	{Snapshot, SnapshotHandler},
+	{Click, ClickHandler},
+	{Hover, HoverHandler},
+	{Fill, FillHandler},
+	{Selector, SelectorHandler},
+}
+
+// Derived slices and maps kept for backward compatibility with existing tests.
 var (
-	SnapshotToolHandlers = map[string]ToolHandler{
-		SnapshotToolKey: SnapshotHandler,
-		ClickToolKey:    ClickHandler,
-		HoverToolKey:    HoverHandler,
-		FillToolKey:     FillHandler,
-		SelectorToolKey: SelectorHandler,
-	}
-	Snapshots = []mcp.Tool{
-		Snapshot,
-		Click,
-		Hover,
-		Fill,
-		Selector,
-	}
+	SnapshotToolHandlers = SnapshotRegistrations.Handlers()
+	Snapshots            = SnapshotRegistrations.Tools()
 )

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -8,10 +8,40 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/aliwatters/rod-mcp/types"
-	"github.com/aliwatters/rod-mcp/utils"
 )
 
 type ToolHandler = func(rodCtx *types.Context) server.ToolHandlerFunc
+
+// Registration pairs an MCP tool definition with its handler factory.
+// It is the single source of truth for tool registration — adding a new tool
+// means adding one Registration entry, not editing both a slice and a map.
+type Registration struct {
+	Tool    mcp.Tool
+	Handler ToolHandler
+}
+
+// Registrations is a named slice of Registration values with helper methods
+// to derive the separate tool-definition slices and handler maps used by the
+// MCP server.
+type Registrations []Registration
+
+// Tools returns all tool definitions as a slice.
+func (rs Registrations) Tools() []mcp.Tool {
+	tools := make([]mcp.Tool, len(rs))
+	for i, r := range rs {
+		tools[i] = r.Tool
+	}
+	return tools
+}
+
+// Handlers returns all handler factories keyed by tool name.
+func (rs Registrations) Handlers() map[string]ToolHandler {
+	m := make(map[string]ToolHandler, len(rs))
+	for _, r := range rs {
+		m[r.Tool.Name] = r.Handler
+	}
+	return m
+}
 
 // toolError logs the error and returns a formatted error for the MCP response.
 func toolError(action string, err error) error {
@@ -19,109 +49,71 @@ func toolError(action string, err error) error {
 	return fmt.Errorf("Failed to %s: %s", action, err)
 }
 
-var (
-	CommonTools = []mcp.Tool{
-		Configure,
-		Navigation,
-		GoBack,
-		GoForward,
-		Reload,
-		PressKey,
-		Type,
-		Screenshot,
-		Pdf,
-		Evaluate,
-		CloseBrowser,
-		SetHeaders,
-		Resize,
-		HandleDialog,
-		TabNew,
-		TabList,
-		TabSelect,
-		TabClose,
-		WaitFor,
-		ConsoleMessages,
-		FileUpload,
-		FillForm,
-		NetworkRequests,
-		Scroll,
-		HTML,
-		Coverage,
-		Cookies,
-		Storage,
-		Permissions,
-		Intercept,
-		ResponseBody,
-		WebSocket,
-		Performance,
-		Drag,
-		A11yAudit,
-		PageInfo,
-		PageStatus,
-		AssertElement,
-		FrameList,
-		Download,
-		Race,
-		Geolocation,
-		BasicAuth,
-		Batch,
-		CompareScreenshots,
-		Login,
-	}
-	CommonToolHandlers = map[string]ToolHandler{
-		ConfigureToolKey:       ConfigureHandler,
-		NavigationToolKey:      NavigationHandler,
-		GoBackToolKey:          GoBackHandler,
-		GoForwardToolKey:       GoForwardHandler,
-		ReloadToolKey:          ReloadHandler,
-		PressKeyToolKey:        PressKeyHandler,
-		TypeToolKey:            TypeHandler,
-		ScreenshotToolKey:      ScreenshotHandler,
-		PdfToolKey:             PdfHandler,
-		EvaluateToolKey:        EvaluateHandler,
-		CloseBrowserToolKey:    CloseBrowserHandler,
-		SetHeadersToolKey:      SetHeadersHandler,
-		ResizeToolKey:          ResizeHandler,
-		HandleDialogToolKey:    HandleDialogHandler,
-		TabNewToolKey:          TabNewHandler,
-		TabListToolKey:         TabListHandler,
-		TabSelectToolKey:       TabSelectHandler,
-		TabCloseToolKey:        TabCloseHandler,
-		WaitForToolKey:         WaitForHandler,
-		ConsoleMessagesToolKey: ConsoleMessagesHandler,
-		FileUploadToolKey:      FileUploadHandler,
-		FillFormToolKey:        FillFormHandler,
-		NetworkRequestsToolKey: NetworkRequestsHandler,
-		ScrollToolKey:          ScrollHandler,
-		HTMLToolKey:            HTMLHandler,
-		CoverageToolKey:        CoverageHandler,
-		CookiesToolKey:         CookiesHandler,
-		StorageToolKey:         StorageHandler,
-		PermissionsToolKey:     PermissionsHandler,
-		InterceptToolKey:       InterceptHandler,
-		ResponseBodyToolKey:    ResponseBodyHandler,
-		WebSocketToolKey:       WebSocketHandler,
-		PerformanceToolKey:     PerformanceHandler,
-		DragToolKey:            DragHandler,
-		A11yAuditToolKey:       A11yAuditHandler,
-		PageInfoToolKey:        PageInfoHandler,
-		PageStatusToolKey:      PageStatusHandler,
-		AssertElementToolKey:   AssertElementHandler,
-		FrameListToolKey:       FrameListHandler,
-		DownloadToolKey:        DownloadHandler,
-		RaceToolKey:            RaceHandler,
-		GeolocationToolKey:          GeolocationHandler,
-		BasicAuthToolKey:            BasicAuthHandler,
-		BatchToolKey:                BatchHandler,
-		CompareScreenshotsToolKey:   CompareScreenshotsHandler,
-		LoginToolKey:                LoginHandler,
-	}
-)
+// CommonRegistrations is the single source of truth for all common (mode-independent)
+// tool definitions and their handlers.
+var CommonRegistrations = Registrations{
+	{Configure, ConfigureHandler},
+	{Navigation, NavigationHandler},
+	{GoBack, GoBackHandler},
+	{GoForward, GoForwardHandler},
+	{Reload, ReloadHandler},
+	{PressKey, PressKeyHandler},
+	{Type, TypeHandler},
+	{Screenshot, ScreenshotHandler},
+	{Pdf, PdfHandler},
+	{Evaluate, EvaluateHandler},
+	{CloseBrowser, CloseBrowserHandler},
+	{SetHeaders, SetHeadersHandler},
+	{Resize, ResizeHandler},
+	{HandleDialog, HandleDialogHandler},
+	{TabNew, TabNewHandler},
+	{TabList, TabListHandler},
+	{TabSelect, TabSelectHandler},
+	{TabClose, TabCloseHandler},
+	{WaitFor, WaitForHandler},
+	{ConsoleMessages, ConsoleMessagesHandler},
+	{FileUpload, FileUploadHandler},
+	{FillForm, FillFormHandler},
+	{NetworkRequests, NetworkRequestsHandler},
+	{Scroll, ScrollHandler},
+	{HTML, HTMLHandler},
+	{Coverage, CoverageHandler},
+	{Cookies, CookiesHandler},
+	{Storage, StorageHandler},
+	{Permissions, PermissionsHandler},
+	{Intercept, InterceptHandler},
+	{ResponseBody, ResponseBodyHandler},
+	{WebSocket, WebSocketHandler},
+	{Performance, PerformanceHandler},
+	{Drag, DragHandler},
+	{A11yAudit, A11yAuditHandler},
+	{PageInfo, PageInfoHandler},
+	{PageStatus, PageStatusHandler},
+	{AssertElement, AssertElementHandler},
+	{FrameList, FrameListHandler},
+	{Download, DownloadHandler},
+	{Race, RaceHandler},
+	{Geolocation, GeolocationHandler},
+	{BasicAuth, BasicAuthHandler},
+	{Batch, BatchHandler},
+	{CompareScreenshots, CompareScreenshotsHandler},
+	{Login, LoginHandler},
+}
 
-var (
-	TextTools        = append(CommonTools, Snapshots...)
-	TextToolHandlers = utils.MergeMaps(CommonToolHandlers, SnapshotToolHandlers)
+// TextRegistrations combines common registrations with text-mode (snapshot) tools.
+var TextRegistrations = append(Registrations(nil), append(CommonRegistrations, SnapshotRegistrations...)...)
 
-	VisionTools            = append(CommonTools, VisionToolDefs...)
-	VisionCombinedHandlers = utils.MergeMaps(CommonToolHandlers, VisionToolHandlers)
+// VisionRegistrations combines common registrations with vision-mode tools.
+var VisionRegistrations = append(Registrations(nil), append(CommonRegistrations, VisionToolRegistrations...)...)
+
+// Derived slices and maps kept for backward compatibility with server.go and tests.
+var (
+	CommonTools        = CommonRegistrations.Tools()
+	CommonToolHandlers = CommonRegistrations.Handlers()
+
+	TextTools        = TextRegistrations.Tools()
+	TextToolHandlers = TextRegistrations.Handlers()
+
+	VisionTools            = VisionRegistrations.Tools()
+	VisionCombinedHandlers = VisionRegistrations.Handlers()
 )

--- a/tools/vision.go
+++ b/tools/vision.go
@@ -113,13 +113,15 @@ var (
 	}
 )
 
+// VisionToolRegistrations is the single source of truth for vision-mode tool
+// definitions and their handlers.
+var VisionToolRegistrations = Registrations{
+	{VisionClick, VisionClickHandler},
+	{VisionFill, VisionFillHandler},
+}
+
+// Derived slices and maps kept for backward compatibility.
 var (
-	VisionToolHandlers = map[string]ToolHandler{
-		VisionClickToolKey: VisionClickHandler,
-		VisionFillToolKey:  VisionFillHandler,
-	}
-	VisionToolDefs = []mcp.Tool{
-		VisionClick,
-		VisionFill,
-	}
+	VisionToolHandlers = VisionToolRegistrations.Handlers()
+	VisionToolDefs     = VisionToolRegistrations.Tools()
 )

--- a/types/context.go
+++ b/types/context.go
@@ -41,22 +41,42 @@ const (
 
 type Context struct {
 	stdContext context.Context
-	config     Config
-	browser    *rod.Browser
-	page       *rod.Page
+
+	// browserLock serialises access to all browser-lifecycle fields:
+	// browser, page, pageCancel, keepaliveCancel, clonedProfileDir, and config.
+	browserLock      sync.Mutex
+	config           Config
+	browser          *rod.Browser
+	page             *rod.Page
 	// pageCancel cancels event-listener goroutines attached to the current page.
 	// It is set when attachEventListeners creates a cancelable page copy, and
 	// called in closePage before the page is closed.
-	pageCancel func()
-	stateLock  sync.Mutex
-	snapshot   *Snapshot
-	mode       Mode
-	events     *eventCollector
-	intercept  *networkInterceptor
+	pageCancel       func()
+	// keepaliveCancel stops the CDP keepalive goroutine when the browser is closed.
+	keepaliveCancel  func()
 	// clonedProfileDir is the temp directory from profile cloning, cleaned up on Close.
 	clonedProfileDir string
-	// keepaliveCancel stops the CDP keepalive goroutine when the browser is closed.
-	keepaliveCancel func()
+
+	// snapshotLock serialises access to the cached ARIA snapshot.
+	// Lock ordering: always acquire snapshotLock before browserLock if both are
+	// needed (EnsureSnapshot reads page under a brief browserLock while holding
+	// snapshotLock).
+	snapshotLock sync.Mutex
+	snapshot     *Snapshot
+
+	// eventsLock serialises access to the event collector (console messages,
+	// network requests, WebSocket frames). Kept separate from browserLock so
+	// event listener goroutines do not contend with browser lifecycle operations.
+	eventsLock sync.Mutex
+	events     *eventCollector
+
+	mode Mode
+
+	// interceptLock serialises access to the network interceptor state.
+	// Kept separate from browserLock to allow intercept configuration without
+	// contending with browser lifecycle operations.
+	interceptLock sync.Mutex
+	intercept     *networkInterceptor
 }
 
 func NewContext(ctx context.Context, cfg Config) *Context {
@@ -77,8 +97,8 @@ func (ctx *Context) EnsurePage() (*rod.Page, error) {
 }
 
 func (ctx *Context) ControlledPage() (*rod.Page, error) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 	if err := ctx.initLocked(); err != nil {
 		return nil, err
 	}
@@ -90,8 +110,8 @@ func (ctx *Context) ControlledPage() (*rod.Page, error) {
 
 // ControlledBrowser returns the browser instance, or an error if no browser is running.
 func (ctx *Context) ControlledBrowser() (*rod.Browser, error) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 	if err := ctx.initLocked(); err != nil {
 		return nil, err
 	}
@@ -102,13 +122,13 @@ func (ctx *Context) ControlledBrowser() (*rod.Browser, error) {
 }
 
 func (ctx *Context) initial() error {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 	return ctx.initLocked()
 }
 
 // initLocked performs lazy initialization of the browser and page.
-// Must be called with stateLock held.
+// Must be called with browserLock held.
 func (ctx *Context) initLocked() error {
 	var err error
 	if ctx.browser == nil {
@@ -142,8 +162,8 @@ func (ctx *Context) Config() Config {
 }
 
 func (ctx *Context) ClosePage() error {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 	return ctx.closePage()
 }
 
@@ -182,18 +202,25 @@ func (ctx *Context) Execute(handlerFunc server.ToolHandlerFunc, handlerCallOpts 
 }
 
 func (ctx *Context) BuildSnapshot() (string, error) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.snapshotLock.Lock()
+	defer ctx.snapshotLock.Unlock()
 	return ctx.buildSnapshotLocked()
 }
 
 // buildSnapshotLocked builds a fresh snapshot and stores it.
-// Must be called with stateLock held.
+// Must be called with snapshotLock held. Reads page and config under a brief
+// browserLock acquisition to avoid holding two locks simultaneously.
 func (ctx *Context) buildSnapshotLocked() (string, error) {
-	if ctx.page == nil {
+	// Read browser state under browserLock and immediately release it.
+	ctx.browserLock.Lock()
+	page := ctx.page
+	compact := ctx.config.CompactSnapshot
+	ctx.browserLock.Unlock()
+
+	if page == nil {
 		return "", errors.New("no active tab, call rod_navigate first")
 	}
-	snapshot, err := BuildSnapshot(ctx.page, ctx.config.CompactSnapshot)
+	snapshot, err := BuildSnapshot(page, compact)
 	if err != nil {
 		return "", err
 	}
@@ -202,8 +229,8 @@ func (ctx *Context) buildSnapshotLocked() (string, error) {
 }
 
 func (ctx *Context) LatestSnapshot() (*Snapshot, error) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.snapshotLock.Lock()
+	defer ctx.snapshotLock.Unlock()
 	if ctx.snapshot == nil {
 		return nil, errors.New("no snapshot available, call rod_snapshot first")
 	}
@@ -214,18 +241,18 @@ func (ctx *Context) LatestSnapshot() (*Snapshot, error) {
 // Call this at the start of any handler that modifies the DOM so that the
 // Execute wrapper (or the next EnsureSnapshot call) rebuilds a fresh snapshot.
 func (ctx *Context) InvalidateSnapshot() {
-	ctx.stateLock.Lock()
+	ctx.snapshotLock.Lock()
 	ctx.snapshot = nil
-	ctx.stateLock.Unlock()
+	ctx.snapshotLock.Unlock()
 }
 
 // EnsureSnapshot returns the latest snapshot, building one if none exists.
-// The check-then-build is performed atomically under stateLock to eliminate
-// the TOCTOU window that existed when lock was released between the nil check
+// The check-then-build is performed atomically under snapshotLock to eliminate
+// the TOCTOU window that existed when the lock was released between the nil check
 // and the build call.
 func (ctx *Context) EnsureSnapshot() (*Snapshot, error) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.snapshotLock.Lock()
+	defer ctx.snapshotLock.Unlock()
 	if ctx.snapshot != nil {
 		return ctx.snapshot, nil
 	}
@@ -236,8 +263,8 @@ func (ctx *Context) EnsureSnapshot() (*Snapshot, error) {
 }
 
 func (ctx *Context) CloseBrowser() error {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 	return ctx.closeBrowser()
 }
 
@@ -292,7 +319,7 @@ const keepaliveInterval = 5 * time.Minute
 
 // startKeepalive launches a background goroutine that periodically sends a
 // lightweight CDP call (Browser.getVersion) to prevent the WebSocket from
-// going idle and being killed. Must be called with stateLock held (or before
+// going idle and being killed. Must be called with browserLock held (or before
 // concurrent access begins). The goroutine stops when keepaliveCancel is called.
 func (ctx *Context) startKeepalive() {
 	if ctx.browser == nil {
@@ -463,8 +490,8 @@ func (ctx *Context) UpdateHeadersForURL(url string) error {
 // next tool call reinitializes with the new configuration.  Pass nil for any
 // field to leave it unchanged.
 func (ctx *Context) Reconfigure(headless *bool, cdpEndpoint *string, stealth *bool) error {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 
 	if headless != nil {
 		ctx.config.Headless = *headless
@@ -483,8 +510,8 @@ func (ctx *Context) Reconfigure(headless *bool, cdpEndpoint *string, stealth *bo
 // Close the browser
 // PS: This method only used because of server exit
 func (ctx *Context) Close() error {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 	if err := ctx.closeBrowser(); err != nil {
 		log.Warnf("close browser: %s", err)
 	}

--- a/types/context.go
+++ b/types/context.go
@@ -184,6 +184,12 @@ func (ctx *Context) Execute(handlerFunc server.ToolHandlerFunc, handlerCallOpts 
 func (ctx *Context) BuildSnapshot() (string, error) {
 	ctx.stateLock.Lock()
 	defer ctx.stateLock.Unlock()
+	return ctx.buildSnapshotLocked()
+}
+
+// buildSnapshotLocked builds a fresh snapshot and stores it.
+// Must be called with stateLock held.
+func (ctx *Context) buildSnapshotLocked() (string, error) {
 	if ctx.page == nil {
 		return "", errors.New("no active tab, call rod_navigate first")
 	}
@@ -214,21 +220,18 @@ func (ctx *Context) InvalidateSnapshot() {
 }
 
 // EnsureSnapshot returns the latest snapshot, building one if none exists.
+// The check-then-build is performed atomically under stateLock to eliminate
+// the TOCTOU window that existed when lock was released between the nil check
+// and the build call.
 func (ctx *Context) EnsureSnapshot() (*Snapshot, error) {
 	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
 	if ctx.snapshot != nil {
-		s := ctx.snapshot
-		ctx.stateLock.Unlock()
-		return s, nil
+		return ctx.snapshot, nil
 	}
-	ctx.stateLock.Unlock()
-
-	// Build a new snapshot (BuildSnapshot acquires stateLock internally).
-	if _, err := ctx.BuildSnapshot(); err != nil {
+	if _, err := ctx.buildSnapshotLocked(); err != nil {
 		return nil, err
 	}
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
 	return ctx.snapshot, nil
 }
 

--- a/types/context_events.go
+++ b/types/context_events.go
@@ -64,52 +64,52 @@ func (ctx *Context) attachEventListeners(page *rod.Page) (cancel func()) {
 			parts = append(parts, arg.Value.String())
 		}
 		text := strings.Join(parts, " ")
-		ctx.stateLock.Lock()
+		ctx.eventsLock.Lock()
 		ctx.events.AddConsoleMessage(ConsoleMessage{
 			Level: string(e.Type),
 			Text:  text,
 		})
-		ctx.stateLock.Unlock()
+		ctx.eventsLock.Unlock()
 	}, func(e *proto.NetworkRequestWillBeSent) {
-		ctx.stateLock.Lock()
+		ctx.eventsLock.Lock()
 		ctx.events.AddNetworkRequest(NetworkRequest{
 			RequestID: string(e.RequestID),
 			Method:    e.Request.Method,
 			URL:       e.Request.URL,
 			Type:      string(e.Type),
 		})
-		ctx.stateLock.Unlock()
+		ctx.eventsLock.Unlock()
 	}, func(e *proto.NetworkResponseReceived) {
-		ctx.stateLock.Lock()
+		ctx.eventsLock.Lock()
 		ctx.events.CompleteNetworkRequest(string(e.RequestID), e.Response.Status, string(e.Type))
-		ctx.stateLock.Unlock()
+		ctx.eventsLock.Unlock()
 	}, func(e *proto.NetworkWebSocketCreated) {
-		ctx.stateLock.Lock()
+		ctx.eventsLock.Lock()
 		ctx.events.AddWSConnection(WebSocketConnection{
 			RequestID: string(e.RequestID),
 			URL:       e.URL,
 		})
-		ctx.stateLock.Unlock()
+		ctx.eventsLock.Unlock()
 	}, func(e *proto.NetworkWebSocketFrameSent) {
-		ctx.stateLock.Lock()
+		ctx.eventsLock.Lock()
 		ctx.events.UpdateWSConnection(string(e.RequestID), func(conn *WebSocketConnection) {
 			conn.SentCount++
 			ctx.events.AppendWSFrame(conn.URL, "sent", e.Response)
 		})
-		ctx.stateLock.Unlock()
+		ctx.eventsLock.Unlock()
 	}, func(e *proto.NetworkWebSocketFrameReceived) {
-		ctx.stateLock.Lock()
+		ctx.eventsLock.Lock()
 		ctx.events.UpdateWSConnection(string(e.RequestID), func(conn *WebSocketConnection) {
 			conn.ReceivedCount++
 			ctx.events.AppendWSFrame(conn.URL, "received", e.Response)
 		})
-		ctx.stateLock.Unlock()
+		ctx.eventsLock.Unlock()
 	}, func(e *proto.NetworkWebSocketClosed) {
-		ctx.stateLock.Lock()
+		ctx.eventsLock.Lock()
 		ctx.events.UpdateWSConnection(string(e.RequestID), func(conn *WebSocketConnection) {
 			conn.Closed = true
 		})
-		ctx.stateLock.Unlock()
+		ctx.eventsLock.Unlock()
 	})()
 
 	return cancelFn
@@ -118,43 +118,43 @@ func (ctx *Context) attachEventListeners(page *rod.Page) (cancel func()) {
 // ConsoleMessages returns captured console messages, optionally filtered by level.
 // If clear is true, the buffer is emptied after returning.
 func (ctx *Context) ConsoleMessages(filterLevel string, clear bool) []ConsoleMessage {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.eventsLock.Lock()
+	defer ctx.eventsLock.Unlock()
 	return ctx.events.ConsoleMessages(filterLevel, clear)
 }
 
 // NetworkRequests returns captured network requests, optionally filtered by URL pattern and method.
 // If clear is true, the buffer is emptied after returning.
 func (ctx *Context) NetworkRequests(filterURL, filterMethod string, clear bool) []NetworkRequest {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.eventsLock.Lock()
+	defer ctx.eventsLock.Unlock()
 	return ctx.events.NetworkRequests(filterURL, filterMethod, clear)
 }
 
 // GetRequestID returns the CDP request ID for a network request at the given index.
 func (ctx *Context) GetRequestID(index int) (string, error) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.eventsLock.Lock()
+	defer ctx.eventsLock.Unlock()
 	return ctx.events.GetRequestID(index)
 }
 
 // WebSocketConnections returns tracked WebSocket connections, optionally filtered by URL.
 func (ctx *Context) WebSocketConnections(urlFilter string) []WebSocketConnection {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.eventsLock.Lock()
+	defer ctx.eventsLock.Unlock()
 	return ctx.events.WebSocketConnections(urlFilter)
 }
 
 // WebSocketFrames returns captured WebSocket frames, optionally filtered by URL and direction.
 func (ctx *Context) WebSocketFrames(urlFilter, direction string) []WebSocketFrame {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.eventsLock.Lock()
+	defer ctx.eventsLock.Unlock()
 	return ctx.events.WebSocketFrames(urlFilter, direction)
 }
 
 // ClearWebSocketData clears all WebSocket connections and frames.
 func (ctx *Context) ClearWebSocketData() {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.eventsLock.Lock()
+	defer ctx.eventsLock.Unlock()
 	ctx.events.ClearWebSocketData()
 }

--- a/types/context_events_test.go
+++ b/types/context_events_test.go
@@ -15,8 +15,8 @@ func newEventsContext() *Context {
 
 // addConsoleMessages populates the context's console ring buffer with test data.
 func addConsoleMessages(ctx *Context, msgs []ConsoleMessage) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.eventsLock.Lock()
+	defer ctx.eventsLock.Unlock()
 	for _, m := range msgs {
 		ctx.events.consoleMessages.Add(m)
 	}
@@ -24,8 +24,8 @@ func addConsoleMessages(ctx *Context, msgs []ConsoleMessage) {
 
 // addNetworkRequests populates the context's network ring buffer with test data.
 func addNetworkRequests(ctx *Context, reqs []NetworkRequest) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.eventsLock.Lock()
+	defer ctx.eventsLock.Unlock()
 	for _, r := range reqs {
 		ctx.events.networkRequests.Add(r)
 	}
@@ -33,8 +33,8 @@ func addNetworkRequests(ctx *Context, reqs []NetworkRequest) {
 
 // addWSFrames populates the context's WebSocket frame ring buffer with test data.
 func addWSFrames(ctx *Context, frames []WebSocketFrame) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.eventsLock.Lock()
+	defer ctx.eventsLock.Unlock()
 	for _, f := range frames {
 		ctx.events.wsFrames.Add(f)
 	}
@@ -308,10 +308,10 @@ func TestWebSocketConnections_Empty(t *testing.T) {
 
 func TestWebSocketConnections_NoFilter(t *testing.T) {
 	ctx := newEventsContext()
-	ctx.stateLock.Lock()
+	ctx.eventsLock.Lock()
 	ctx.events.wsConnections.Add(WebSocketConnection{RequestID: "ws1", URL: "wss://a.com/ws", Closed: false})
 	ctx.events.wsConnections.Add(WebSocketConnection{RequestID: "ws2", URL: "wss://b.com/ws", Closed: true})
-	ctx.stateLock.Unlock()
+	ctx.eventsLock.Unlock()
 
 	conns := ctx.WebSocketConnections("")
 	if len(conns) != 2 {
@@ -321,10 +321,10 @@ func TestWebSocketConnections_NoFilter(t *testing.T) {
 
 func TestWebSocketConnections_URLFilter(t *testing.T) {
 	ctx := newEventsContext()
-	ctx.stateLock.Lock()
+	ctx.eventsLock.Lock()
 	ctx.events.wsConnections.Add(WebSocketConnection{RequestID: "ws1", URL: "wss://a.com/ws"})
 	ctx.events.wsConnections.Add(WebSocketConnection{RequestID: "ws2", URL: "wss://b.com/ws"})
-	ctx.stateLock.Unlock()
+	ctx.eventsLock.Unlock()
 
 	conns := ctx.WebSocketConnections("a.com")
 	if len(conns) != 1 {
@@ -420,10 +420,10 @@ func TestWebSocketFrames_URLAndDirectionFilter(t *testing.T) {
 func TestClearWebSocketData_ClearsAll(t *testing.T) {
 	ctx := newEventsContext()
 
-	ctx.stateLock.Lock()
+	ctx.eventsLock.Lock()
 	idx := ctx.events.wsConnections.AddWithIndex(WebSocketConnection{RequestID: "ws1", URL: "wss://a.com"})
 	ctx.events.wsConnIndex = map[string]int{"ws1": idx}
-	ctx.stateLock.Unlock()
+	ctx.eventsLock.Unlock()
 	addWSFrames(ctx, []WebSocketFrame{
 		{URL: "wss://a.com", Direction: "sent", PayloadData: "data"},
 	})
@@ -440,9 +440,9 @@ func TestClearWebSocketData_ClearsAll(t *testing.T) {
 		t.Errorf("expected 0 frames after clear, got %d", len(frames))
 	}
 
-	ctx.stateLock.Lock()
+	ctx.eventsLock.Lock()
 	connIndex := ctx.events.wsConnIndex
-	ctx.stateLock.Unlock()
+	ctx.eventsLock.Unlock()
 	if connIndex != nil {
 		t.Error("wsConnIndex should be nil after clear")
 	}

--- a/types/context_intercept.go
+++ b/types/context_intercept.go
@@ -2,36 +2,36 @@ package types
 
 // InterceptEnabled returns whether request interception is currently enabled.
 func (ctx *Context) InterceptEnabled() bool {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.interceptLock.Lock()
+	defer ctx.interceptLock.Unlock()
 	return ctx.intercept.Enabled()
 }
 
 // SetInterceptEnabled sets whether interception is enabled.
 // When disabling, any existing intercept listener goroutine is cancelled.
 func (ctx *Context) SetInterceptEnabled(enabled bool) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.interceptLock.Lock()
+	defer ctx.interceptLock.Unlock()
 	ctx.intercept.SetEnabled(enabled)
 }
 
 // SetInterceptCancel stores the cancel function for the intercept EachEvent goroutine.
 func (ctx *Context) SetInterceptCancel(cancel func()) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.interceptLock.Lock()
+	defer ctx.interceptLock.Unlock()
 	ctx.intercept.SetCancel(cancel)
 }
 
 // AddInterceptRule appends an interception rule.
 func (ctx *Context) AddInterceptRule(rule InterceptRule) {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.interceptLock.Lock()
+	defer ctx.interceptLock.Unlock()
 	ctx.intercept.AddRule(rule)
 }
 
 // InterceptRules returns a copy of the current interception rules.
 func (ctx *Context) InterceptRules() []InterceptRule {
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.interceptLock.Lock()
+	defer ctx.interceptLock.Unlock()
 	return ctx.intercept.Rules()
 }

--- a/types/context_tabs.go
+++ b/types/context_tabs.go
@@ -20,8 +20,8 @@ func (ctx *Context) NewTab(url string) (*rod.Page, error) {
 	if err := ctx.initial(); err != nil {
 		return nil, err
 	}
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 
 	var page *rod.Page
 	var err error
@@ -42,8 +42,8 @@ func (ctx *Context) ListTabs() ([]TabInfo, error) {
 	if err := ctx.initial(); err != nil {
 		return nil, err
 	}
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 
 	pages, err := ctx.browser.Pages()
 	if err != nil {
@@ -71,8 +71,8 @@ func (ctx *Context) SelectTab(index int) (*rod.Page, error) {
 	if err := ctx.initial(); err != nil {
 		return nil, err
 	}
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 
 	pages, err := ctx.browser.Pages()
 	if err != nil {
@@ -91,8 +91,8 @@ func (ctx *Context) CloseTab(index int) error {
 	if err := ctx.initial(); err != nil {
 		return err
 	}
-	ctx.stateLock.Lock()
-	defer ctx.stateLock.Unlock()
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 
 	pages, err := ctx.browser.Pages()
 	if err != nil {

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -88,15 +88,15 @@ func TestInvalidateSnapshot_ClearsSnapshot(t *testing.T) {
 	ctx := newTestContext()
 
 	// Manually set a snapshot to simulate a previous build.
-	ctx.stateLock.Lock()
+	ctx.snapshotLock.Lock()
 	ctx.snapshot = &Snapshot{}
-	ctx.stateLock.Unlock()
+	ctx.snapshotLock.Unlock()
 
 	ctx.InvalidateSnapshot()
 
-	ctx.stateLock.Lock()
+	ctx.snapshotLock.Lock()
 	snap := ctx.snapshot
-	ctx.stateLock.Unlock()
+	ctx.snapshotLock.Unlock()
 
 	if snap != nil {
 		t.Error("InvalidateSnapshot: snapshot should be nil after invalidation")
@@ -115,9 +115,9 @@ func TestLatestSnapshot_ReturnsExisting(t *testing.T) {
 	ctx := newTestContext()
 
 	expected := &Snapshot{textSnapshot: "test-snapshot"}
-	ctx.stateLock.Lock()
+	ctx.snapshotLock.Lock()
 	ctx.snapshot = expected
-	ctx.stateLock.Unlock()
+	ctx.snapshotLock.Unlock()
 
 	got, err := ctx.LatestSnapshot()
 	if err != nil {
@@ -132,9 +132,9 @@ func TestInvalidateSnapshot_ThenLatestSnapshot_Errors(t *testing.T) {
 	ctx := newTestContext()
 
 	// Set and then invalidate.
-	ctx.stateLock.Lock()
+	ctx.snapshotLock.Lock()
 	ctx.snapshot = &Snapshot{}
-	ctx.stateLock.Unlock()
+	ctx.snapshotLock.Unlock()
 
 	ctx.InvalidateSnapshot()
 
@@ -184,9 +184,9 @@ func TestEnsureSnapshot_ReturnsExistingSnapshot(t *testing.T) {
 
 	// Pre-populate the snapshot so EnsureSnapshot returns it without building.
 	expected := &Snapshot{textSnapshot: "cached-snapshot"}
-	ctx.stateLock.Lock()
+	ctx.snapshotLock.Lock()
 	ctx.snapshot = expected
-	ctx.stateLock.Unlock()
+	ctx.snapshotLock.Unlock()
 
 	got, err := ctx.EnsureSnapshot()
 	if err != nil {

--- a/types/cookies.go
+++ b/types/cookies.go
@@ -127,6 +127,11 @@ func decryptCookieValue(encrypted []byte, key []byte) (string, error) {
 // buildDomainFilter constructs an SQL WHERE clause for the given domain patterns.
 // Wildcard patterns (*.example.com) match any subdomain; plain patterns match as a suffix.
 // Returns an error if any pattern is invalid, and an empty string if domains is empty.
+//
+// Defense-in-depth: isValidDomainPattern rejects all SQL metacharacters before this
+// function is called. As a second layer, sqliteLikeEscape escapes LIKE metacharacters
+// ('_' and '%') within the domain suffix so no user-controlled value is ever
+// interpolated raw into the query string.
 func buildDomainFilter(domains []string) (string, error) {
 	if len(domains) == 0 {
 		return "", nil
@@ -140,17 +145,31 @@ func buildDomainFilter(domains []string) (string, error) {
 		if !isValidDomainPattern(d) {
 			return "", fmt.Errorf("invalid domain pattern %q", d)
 		}
+		// Strip the leading '*' for wildcard patterns (*.example.com → .example.com).
+		suffix := d
 		if strings.HasPrefix(d, "*.") {
-			suffix := d[1:]
-			conditions = append(conditions, fmt.Sprintf("host_key LIKE '%%%s'", suffix))
-		} else {
-			conditions = append(conditions, fmt.Sprintf("host_key LIKE '%%%s'", d))
+			suffix = d[1:]
 		}
+		// Escape LIKE metacharacters within the domain suffix as a second layer of
+		// defense. The domain allowlist already forbids '%' and '_', so this is
+		// belt-and-suspenders, not the primary guard.
+		escaped := sqliteLikeEscape(suffix)
+		conditions = append(conditions, fmt.Sprintf("host_key LIKE '%%%s' ESCAPE '\\'", escaped))
 	}
 	if len(conditions) == 0 {
 		return "", nil
 	}
 	return " WHERE " + strings.Join(conditions, " OR "), nil
+}
+
+// sqliteLikeEscape escapes SQLite LIKE pattern metacharacters ('%' and '_') in s
+// using a backslash escape. The returned string is safe to embed inside a
+// LIKE '...' ESCAPE '\\' clause.
+func sqliteLikeEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "%", `\%`)
+	s = strings.ReplaceAll(s, "_", `\_`)
+	return s
 }
 
 // parseCookieLine parses a single tab-separated cookie row from sqlite3 output

--- a/types/cookies_test.go
+++ b/types/cookies_test.go
@@ -264,3 +264,105 @@ func TestDecryptCookieValue_V11Prefix(t *testing.T) {
 		t.Errorf("decryptCookieValue v11: got %q, want %q", got, string(plaintext))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// sqliteLikeEscape
+// ---------------------------------------------------------------------------
+
+func TestSQLiteLikeEscape(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"example.com", "example.com"},
+		{".example.com", ".example.com"},
+		{"no_special", `no\_special`},
+		{"has%percent", `has\%percent`},
+		{`has\backslash`, `has\\backslash`},
+		{"combined_%_test", `combined\_\%\_test`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sqliteLikeEscape(tt.input)
+			if got != tt.want {
+				t.Errorf("sqliteLikeEscape(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildDomainFilter
+// ---------------------------------------------------------------------------
+
+func TestBuildDomainFilter_Empty(t *testing.T) {
+	got, err := buildDomainFilter(nil)
+	if err != nil {
+		t.Fatalf("buildDomainFilter(nil): unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("buildDomainFilter(nil) = %q, want empty", got)
+	}
+}
+
+func TestBuildDomainFilter_SingleDomain(t *testing.T) {
+	got, err := buildDomainFilter([]string{"example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := " WHERE host_key LIKE '%example.com' ESCAPE '\\'"
+	if got != want {
+		t.Errorf("buildDomainFilter([example.com]) = %q, want %q", got, want)
+	}
+}
+
+func TestBuildDomainFilter_WildcardDomain(t *testing.T) {
+	got, err := buildDomainFilter([]string{"*.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := " WHERE host_key LIKE '%.example.com' ESCAPE '\\'"
+	if got != want {
+		t.Errorf("buildDomainFilter([*.example.com]) = %q, want %q", got, want)
+	}
+}
+
+func TestBuildDomainFilter_MultipleDomains(t *testing.T) {
+	got, err := buildDomainFilter([]string{"foo.com", "bar.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := " WHERE host_key LIKE '%foo.com' ESCAPE '\\' OR host_key LIKE '%bar.com' ESCAPE '\\'"
+	if got != want {
+		t.Errorf("buildDomainFilter([foo.com, bar.com]) = %q, want %q", got, want)
+	}
+}
+
+func TestBuildDomainFilter_InvalidPatternRejected(t *testing.T) {
+	adversarial := []string{
+		"evil'; DROP TABLE cookies; --",
+		"bad domain",
+		"semi;colon.com",
+		"has/slash.com",
+		"http://example.com",
+	}
+	for _, d := range adversarial {
+		t.Run(d, func(t *testing.T) {
+			_, err := buildDomainFilter([]string{d})
+			if err == nil {
+				t.Errorf("buildDomainFilter(%q): expected error for adversarial input, got nil", d)
+			}
+		})
+	}
+}
+
+func TestBuildDomainFilter_SkipsBlankEntries(t *testing.T) {
+	got, err := buildDomainFilter([]string{"", "  ", "example.com", ""})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := " WHERE host_key LIKE '%example.com' ESCAPE '\\'"
+	if got != want {
+		t.Errorf("buildDomainFilter with blanks = %q, want %q", got, want)
+	}
+}

--- a/types/event_collector.go
+++ b/types/event_collector.go
@@ -19,7 +19,7 @@ const (
 )
 
 // eventCollector owns the ring buffers for console messages, network requests,
-// and WebSocket tracking. All methods assume the caller holds Context.stateLock.
+// and WebSocket tracking. All methods assume the caller holds Context.eventsLock.
 type eventCollector struct {
 	consoleMessages *RingBuffer[ConsoleMessage]
 	networkRequests *RingBuffer[NetworkRequest]
@@ -43,13 +43,13 @@ func newEventCollector() *eventCollector {
 	}
 }
 
-// AddConsoleMessage records a console message. Must be called with stateLock held.
+// AddConsoleMessage records a console message. Must be called with eventsLock held.
 func (ec *eventCollector) AddConsoleMessage(msg ConsoleMessage) {
 	ec.consoleMessages.Add(msg)
 }
 
 // AddNetworkRequest records a new outgoing request and tracks it as pending.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) AddNetworkRequest(req NetworkRequest) {
 	if ec.pendingRequests == nil {
 		ec.pendingRequests = make(map[string]int)
@@ -59,7 +59,7 @@ func (ec *eventCollector) AddNetworkRequest(req NetworkRequest) {
 }
 
 // CompleteNetworkRequest updates a pending request with its response status and type.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) CompleteNetworkRequest(requestID string, status int, typ string) {
 	if idx, ok := ec.pendingRequests[requestID]; ok {
 		ec.networkRequests.UpdateAt(idx, func(req *NetworkRequest) {
@@ -70,7 +70,7 @@ func (ec *eventCollector) CompleteNetworkRequest(requestID string, status int, t
 	}
 }
 
-// AddWSConnection records a new WebSocket connection. Must be called with stateLock held.
+// AddWSConnection records a new WebSocket connection. Must be called with eventsLock held.
 func (ec *eventCollector) AddWSConnection(conn WebSocketConnection) {
 	if ec.wsConnIndex == nil {
 		ec.wsConnIndex = make(map[string]int)
@@ -80,7 +80,7 @@ func (ec *eventCollector) AddWSConnection(conn WebSocketConnection) {
 }
 
 // UpdateWSConnection calls fn on the WebSocket connection identified by requestID.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) UpdateWSConnection(requestID string, fn func(*WebSocketConnection)) {
 	if idx, ok := ec.wsConnIndex[requestID]; ok {
 		ec.wsConnections.UpdateAt(idx, fn)
@@ -88,7 +88,7 @@ func (ec *eventCollector) UpdateWSConnection(requestID string, fn func(*WebSocke
 }
 
 // AppendWSFrame adds a WebSocket frame to the ring buffer.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) AppendWSFrame(url, direction string, frame *proto.NetworkWebSocketFrame) {
 	ec.wsFrames.Add(WebSocketFrame{
 		URL:         url,
@@ -100,7 +100,7 @@ func (ec *eventCollector) AppendWSFrame(url, direction string, frame *proto.Netw
 
 // ConsoleMessages returns captured console messages, optionally filtered by level.
 // If clear is true, the buffer is emptied after returning.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) ConsoleMessages(filterLevel string, clear bool) []ConsoleMessage {
 	all := ec.consoleMessages.Slice()
 	result := filterSlice(all, func(msg ConsoleMessage) bool {
@@ -127,7 +127,7 @@ func (ec *eventCollector) ConsoleMessages(filterLevel string, clear bool) []Cons
 
 // NetworkRequests returns captured network requests, optionally filtered by URL pattern and method.
 // If clear is true, the buffer is emptied after returning.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) NetworkRequests(filterURL, filterMethod string, clear bool) []NetworkRequest {
 	result := filterSlice(ec.networkRequests.Slice(), func(req NetworkRequest) bool {
 		if filterURL != "" && !strings.Contains(req.URL, filterURL) {
@@ -148,7 +148,7 @@ func (ec *eventCollector) NetworkRequests(filterURL, filterMethod string, clear 
 }
 
 // GetRequestID returns the CDP request ID for a network request at the given index.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) GetRequestID(index int) (string, error) {
 	all := ec.networkRequests.Slice()
 	if len(all) == 0 {
@@ -161,7 +161,7 @@ func (ec *eventCollector) GetRequestID(index int) (string, error) {
 }
 
 // WebSocketConnections returns tracked WebSocket connections, optionally filtered by URL.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) WebSocketConnections(urlFilter string) []WebSocketConnection {
 	return filterSlice(ec.wsConnections.Slice(), func(conn WebSocketConnection) bool {
 		return urlFilter == "" || strings.Contains(conn.URL, urlFilter)
@@ -169,7 +169,7 @@ func (ec *eventCollector) WebSocketConnections(urlFilter string) []WebSocketConn
 }
 
 // WebSocketFrames returns captured WebSocket frames, optionally filtered by URL and direction.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) WebSocketFrames(urlFilter, direction string) []WebSocketFrame {
 	return filterSlice(ec.wsFrames.Slice(), func(f WebSocketFrame) bool {
 		if urlFilter != "" && !strings.Contains(f.URL, urlFilter) {
@@ -183,7 +183,7 @@ func (ec *eventCollector) WebSocketFrames(urlFilter, direction string) []WebSock
 }
 
 // ClearWebSocketData clears all WebSocket connections and frames.
-// Must be called with stateLock held.
+// Must be called with eventsLock held.
 func (ec *eventCollector) ClearWebSocketData() {
 	ec.wsConnections.Clear()
 	ec.wsConnIndex = nil

--- a/types/network_interceptor.go
+++ b/types/network_interceptor.go
@@ -5,7 +5,7 @@ import (
 )
 
 // networkInterceptor owns the state for CDP request interception (Fetch domain).
-// All methods assume the caller holds Context.stateLock.
+// All methods assume the caller holds Context.interceptLock.
 type networkInterceptor struct {
 	rules   []InterceptRule
 	enabled bool
@@ -29,14 +29,14 @@ type InterceptRule struct {
 }
 
 // Enabled returns whether request interception is currently enabled.
-// Must be called with stateLock held.
+// Must be called with interceptLock held.
 func (ni *networkInterceptor) Enabled() bool {
 	return ni.enabled
 }
 
 // SetEnabled sets whether interception is enabled.
 // When disabling, any existing intercept listener goroutine is cancelled and rules are cleared.
-// Must be called with stateLock held.
+// Must be called with interceptLock held.
 func (ni *networkInterceptor) SetEnabled(enabled bool) {
 	ni.enabled = enabled
 	if !enabled {
@@ -50,7 +50,7 @@ func (ni *networkInterceptor) SetEnabled(enabled bool) {
 
 // SetCancel stores the cancel function for the intercept EachEvent goroutine.
 // Any prior listener is cancelled before replacing.
-// Must be called with stateLock held.
+// Must be called with interceptLock held.
 func (ni *networkInterceptor) SetCancel(cancel func()) {
 	if ni.cancel != nil {
 		ni.cancel()
@@ -59,7 +59,7 @@ func (ni *networkInterceptor) SetCancel(cancel func()) {
 }
 
 // Cancel cancels the intercept listener goroutine if one is running, and
-// clears the cancel function. Must be called with stateLock held.
+// clears the cancel function. Must be called with interceptLock held.
 func (ni *networkInterceptor) Cancel() {
 	if ni.cancel != nil {
 		ni.cancel()
@@ -68,13 +68,13 @@ func (ni *networkInterceptor) Cancel() {
 }
 
 // AddRule appends an interception rule.
-// Must be called with stateLock held.
+// Must be called with interceptLock held.
 func (ni *networkInterceptor) AddRule(rule InterceptRule) {
 	ni.rules = append(ni.rules, rule)
 }
 
 // Rules returns a copy of the current interception rules.
-// Must be called with stateLock held.
+// Must be called with interceptLock held.
 func (ni *networkInterceptor) Rules() []InterceptRule {
 	rules := make([]InterceptRule, len(ni.rules))
 	copy(rules, ni.rules)


### PR DESCRIPTION
## Summary

- **fix**: eliminate raw SQL interpolation in cookie domain filtering — add `sqliteLikeEscape()` and `ESCAPE '\\'` clauses as second layer beyond the `isValidDomainPattern` allowlist (#275)
- **fix**: TOCTOU race in `EnsureSnapshot` — extract `buildSnapshotLocked()` so the nil-check and build are atomic under a single lock acquisition (#271)
- **refactor**: DRY tool/handler registration — introduce `Registration{Tool, Handler}` and `Registrations` type; `server.go` iterates registrations directly, eliminating the parallel slice+map maintenance (#267)
- **refactor**: extract `CookiesHandler` switch cases into six focused per-action functions (`cookiesGet`, `cookiesSet`, `cookiesDelete`, `cookiesClear`, `cookiesSave`, `cookiesRestore`) (#272)
- **refactor**: standardize arg extraction — replace panicking `args["key"].(T)` assertions with typed helpers; add `getBoolArg`, `getOptionalBoolPtr`, `getOptionalStringPtr` (#273)
- **refactor**: split monolithic `stateLock` into per-subsystem locks: `browserLock`, `snapshotLock`, `eventsLock`, `interceptLock` — verified with `go test -race ./...` (#274)

Closes #275, Closes #271, Closes #267, Closes #272, Closes #273, Closes #274

## Test plan

- [x] `go test ./...` passes
- [x] `go test -race ./...` passes — no races detected
- [x] `TestBuildDomainFilter_InvalidPatternRejected` verifies adversarial SQL injection patterns are rejected
- [x] `TestRegistrationsDRY` verifies tools and handlers cannot drift apart
- [x] `TestTextRegistrationsComplete` verifies text mode includes all common + snapshot tools
- [x] No raw SQL interpolation remains — only `sqliteLikeEscape()`-escaped values in LIKE clauses
- [x] `EnsureSnapshot` TOCTOU window closed — single `snapshotLock` acquisition covers nil-check and build
- [x] Lock ordering: always `snapshotLock` → `browserLock`, never reversed