### PR TITLE
refactor: rod-mcp code quality batch

### DIFF
--- a/tools/constants.go
+++ b/tools/constants.go
@@ -33,9 +33,6 @@ const (
 
 	// defaultFormContainerTimeout is the max time to wait for a modal form container to appear.
 	defaultFormContainerTimeout = 5 * time.Second
-
-	// dragStepDelay is the pause between mouse-move steps during drag operations.
-	dragStepDelay = 10 * time.Millisecond
 )
 
 // Default parameter values for tool options.

--- a/tools/drag.go
+++ b/tools/drag.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
@@ -84,64 +83,33 @@ var (
 				return toolErr("drag target", err)
 			}
 
+			mouse := page.Mouse
+
 			// Move to start position
-			if err := (proto.InputDispatchMouseEvent{
-				Type: proto.InputDispatchMouseEventTypeMouseMoved,
-				X:    startX,
-				Y:    startY,
-			}).Call(page); err != nil {
+			if err := mouse.MoveTo(proto.NewPoint(startX, startY)); err != nil {
 				return toolErr("move to start", err)
 			}
 
 			// Press at start
-			if err := (proto.InputDispatchMouseEvent{
-				Type:       proto.InputDispatchMouseEventTypeMousePressed,
-				X:          startX,
-				Y:          startY,
-				Button:     proto.InputMouseButtonLeft,
-				ClickCount: 1,
-			}).Call(page); err != nil {
+			if err := mouse.Down(proto.InputMouseButtonLeft, 1); err != nil {
 				return toolErr("mouse press", err)
 			}
 
-			// Ensure mouse is released even if move steps fail
+			// Ensure mouse is released even if the linear move fails
 			mouseReleased := false
 			defer func() {
 				if !mouseReleased {
-					_ = (proto.InputDispatchMouseEvent{
-						Type:       proto.InputDispatchMouseEventTypeMouseReleased,
-						X:          endX,
-						Y:          endY,
-						Button:     proto.InputMouseButtonLeft,
-						ClickCount: 1,
-					}).Call(page)
+					_ = mouse.Up(proto.InputMouseButtonLeft, 1)
 				}
 			}()
 
-			// Move in steps
-			for i := 1; i <= steps; i++ {
-				t := float64(i) / float64(steps)
-				x := startX + (endX-startX)*t
-				y := startY + (endY-startY)*t
-				if err := (proto.InputDispatchMouseEvent{
-					Type:   proto.InputDispatchMouseEventTypeMouseMoved,
-					X:      x,
-					Y:      y,
-					Button: proto.InputMouseButtonLeft,
-				}).Call(page); err != nil {
-					return toolErr("mouse move", err)
-				}
-				time.Sleep(dragStepDelay)
+			// Move to end in steps using rod's built-in linear interpolation
+			if err := mouse.MoveLinear(proto.NewPoint(endX, endY), steps); err != nil {
+				return toolErr("mouse move", err)
 			}
 
 			// Release at end
-			if err := (proto.InputDispatchMouseEvent{
-				Type:       proto.InputDispatchMouseEventTypeMouseReleased,
-				X:          endX,
-				Y:          endY,
-				Button:     proto.InputMouseButtonLeft,
-				ClickCount: 1,
-			}).Call(page); err != nil {
+			if err := mouse.Up(proto.InputMouseButtonLeft, 1); err != nil {
 				return toolErr("mouse release", err)
 			}
 			mouseReleased = true

--- a/types/cookies.go
+++ b/types/cookies.go
@@ -62,18 +62,54 @@ func chromeSameSiteToCDP(ss int) proto.NetworkCookieSameSite {
 	}
 }
 
-// readChromeEncryptionKey reads the Chrome Safe Storage password from the macOS Keychain.
-func readChromeEncryptionKey() (string, error) {
+// KeychainReader reads a secret from the OS keychain.
+// The default implementation calls the macOS `security` CLI.
+type KeychainReader interface {
+	ReadKey(service, account string) (string, error)
+}
+
+// SQLiteQuerier executes a read-only query against an SQLite database file and
+// returns the raw tab-separated output. The default implementation delegates to
+// the sqlite3 CLI binary.
+type SQLiteQuerier interface {
+	Query(dbPath, separator, query string) ([]byte, error)
+}
+
+// defaultKeychainReader is the production KeychainReader that calls the macOS
+// `security find-generic-password` command.
+type defaultKeychainReader struct{}
+
+func (defaultKeychainReader) ReadKey(service, account string) (string, error) {
 	if runtime.GOOS != "darwin" {
 		return "", fmt.Errorf("cookie decryption is currently only supported on macOS")
 	}
-
-	cmd := exec.Command("security", "find-generic-password", "-w", "-s", "Chrome Safe Storage", "-a", "Chrome")
+	cmd := exec.Command("security", "find-generic-password", "-w", "-s", service, "-a", account)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to read Chrome Safe Storage from Keychain: %w (you may need to allow access)", err)
+		return "", fmt.Errorf("failed to read %s from Keychain for account %s: %w (you may need to allow access)", service, account, err)
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// defaultSQLiteQuerier is the production SQLiteQuerier that calls the sqlite3 CLI.
+type defaultSQLiteQuerier struct{}
+
+func (defaultSQLiteQuerier) Query(dbPath, separator, query string) ([]byte, error) {
+	sqlite3Path, err := exec.LookPath("sqlite3")
+	if err != nil {
+		return nil, fmt.Errorf("sqlite3 not found in PATH")
+	}
+	cmd := exec.Command(sqlite3Path, "-separator", separator, dbPath, query)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("sqlite3 query failed: %w", err)
+	}
+	return out, nil
+}
+
+// readChromeEncryptionKey reads the Chrome Safe Storage password from the macOS Keychain.
+func readChromeEncryptionKey() (string, error) {
+	return defaultKeychainReader{}.ReadKey("Chrome Safe Storage", "Chrome")
 }
 
 // deriveChromeKey derives the AES-128-CBC key from the Keychain password using PBKDF2.
@@ -229,24 +265,27 @@ func parseCookieLine(line string, key []byte) (*proto.NetworkCookieParam, error)
 // ReadChromeCookies reads and decrypts cookies from a Chrome profile's Cookies SQLite DB.
 // If domains is non-empty, only cookies matching those domains are returned.
 // Returns CDP-compatible cookie params ready for injection.
+// Uses the default production implementations of KeychainReader and SQLiteQuerier.
 func ReadChromeCookies(profileDir string, domains []string) ([]*proto.NetworkCookieParam, error) {
+	return ReadChromeCookiesWithDeps(profileDir, domains, defaultKeychainReader{}, defaultSQLiteQuerier{})
+}
+
+// ReadChromeCookiesWithDeps is the injectable variant of ReadChromeCookies.
+// Callers may supply custom KeychainReader and SQLiteQuerier implementations for
+// testing or alternative OS integrations.
+func ReadChromeCookiesWithDeps(profileDir string, domains []string, kr KeychainReader, sq SQLiteQuerier) ([]*proto.NetworkCookieParam, error) {
 	cookiesDB := filepath.Join(profileDir, "Default", "Cookies")
 	if _, err := os.Stat(cookiesDB); os.IsNotExist(err) {
 		return nil, fmt.Errorf("cookies database not found at %s", cookiesDB)
 	}
 
-	password, err := readChromeEncryptionKey()
+	password, err := kr.ReadKey("Chrome Safe Storage", "Chrome")
 	if err != nil {
 		return nil, err
 	}
 	key, err := deriveChromeKey(password)
 	if err != nil {
 		return nil, fmt.Errorf("derive encryption key: %w", err)
-	}
-
-	sqlite3Path, err := exec.LookPath("sqlite3")
-	if err != nil {
-		return nil, fmt.Errorf("sqlite3 not found in PATH")
 	}
 
 	whereClause, err := buildDomainFilter(domains)
@@ -258,10 +297,9 @@ func ReadChromeCookies(profileDir string, domains []string) ([]*proto.NetworkCoo
 		"SELECT host_key, name, hex(encrypted_value), value, path, is_secure, is_httponly, expires_utc, samesite FROM cookies%s;",
 		whereClause,
 	)
-	cmd := exec.Command(sqlite3Path, "-separator", "\t", cookiesDB, query)
-	out, err := cmd.Output()
+	out, err := sq.Query(cookiesDB, "\t", query)
 	if err != nil {
-		return nil, fmt.Errorf("sqlite3 query failed: %w", err)
+		return nil, err
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")

--- a/types/cookies_test.go
+++ b/types/cookies_test.go
@@ -2,6 +2,9 @@ package types
 
 import (
 	"crypto/aes"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-rod/rod/lib/proto"
@@ -364,5 +367,118 @@ func TestBuildDomainFilter_SkipsBlankEntries(t *testing.T) {
 	want := " WHERE host_key LIKE '%example.com' ESCAPE '\\'"
 	if got != want {
 		t.Errorf("buildDomainFilter with blanks = %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ReadChromeCookiesWithDeps — DI / testability
+// ---------------------------------------------------------------------------
+
+// stubKeychainReader is a test double for KeychainReader.
+type stubKeychainReader struct {
+	password string
+	err      error
+}
+
+func (s stubKeychainReader) ReadKey(_, _ string) (string, error) {
+	return s.password, s.err
+}
+
+// stubSQLiteQuerier is a test double for SQLiteQuerier.
+type stubSQLiteQuerier struct {
+	output []byte
+	err    error
+}
+
+func (s stubSQLiteQuerier) Query(_, _, _ string) ([]byte, error) {
+	return s.output, s.err
+}
+
+// makeTempCookiesDB creates a minimal directory structure that satisfies the
+// os.Stat check in ReadChromeCookiesWithDeps (Default/Cookies must exist).
+func makeTempCookiesDB(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	defaultDir := filepath.Join(dir, "Default")
+	if err := os.MkdirAll(defaultDir, 0o700); err != nil {
+		t.Fatalf("mkdir Default: %v", err)
+	}
+	cookiesPath := filepath.Join(defaultDir, "Cookies")
+	if err := os.WriteFile(cookiesPath, []byte("placeholder"), 0o600); err != nil {
+		t.Fatalf("write Cookies: %v", err)
+	}
+	return dir
+}
+
+func TestReadChromeCookiesWithDeps_KeychainError(t *testing.T) {
+	profileDir := makeTempCookiesDB(t)
+	kr := stubKeychainReader{err: fmt.Errorf("keychain unavailable")}
+	sq := stubSQLiteQuerier{}
+
+	_, err := ReadChromeCookiesWithDeps(profileDir, nil, kr, sq)
+	if err == nil {
+		t.Fatal("expected error when keychain read fails, got nil")
+	}
+}
+
+func TestReadChromeCookiesWithDeps_SQLiteError(t *testing.T) {
+	profileDir := makeTempCookiesDB(t)
+	kr := stubKeychainReader{password: "testpassword"}
+	sq := stubSQLiteQuerier{err: fmt.Errorf("sqlite3 not found")}
+
+	_, err := ReadChromeCookiesWithDeps(profileDir, nil, kr, sq)
+	if err == nil {
+		t.Fatal("expected error when sqlite3 query fails, got nil")
+	}
+}
+
+func TestReadChromeCookiesWithDeps_MissingDB(t *testing.T) {
+	kr := stubKeychainReader{password: "testpassword"}
+	sq := stubSQLiteQuerier{}
+
+	_, err := ReadChromeCookiesWithDeps("/nonexistent/profile", nil, kr, sq)
+	if err == nil {
+		t.Fatal("expected error for missing cookies database, got nil")
+	}
+}
+
+func TestReadChromeCookiesWithDeps_EmptyOutput(t *testing.T) {
+	profileDir := makeTempCookiesDB(t)
+	kr := stubKeychainReader{password: "testpassword"}
+	sq := stubSQLiteQuerier{output: []byte("")}
+
+	cookies, err := ReadChromeCookiesWithDeps(profileDir, nil, kr, sq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cookies) != 0 {
+		t.Errorf("expected 0 cookies for empty sqlite output, got %d", len(cookies))
+	}
+}
+
+func TestReadChromeCookiesWithDeps_PlaintextCookie(t *testing.T) {
+	profileDir := makeTempCookiesDB(t)
+
+	// Build a real AES key from a known password so parseCookieLine can be invoked
+	// with a plaintext value (no encryption needed in this path).
+	kr := stubKeychainReader{password: "testpassword"}
+
+	// Tab-separated row: host_key, name, encrypted_hex, plain_value, path,
+	// is_secure, is_httponly, expires_utc, samesite
+	row := ".example.com\tsession\t\thello-value\t/\t1\t0\t0\t0\n"
+	sq := stubSQLiteQuerier{output: []byte(row)}
+
+	cookies, err := ReadChromeCookiesWithDeps(profileDir, nil, kr, sq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+	if cookies[0].Value != "hello-value" {
+		t.Errorf("cookie value = %q, want %q", cookies[0].Value, "hello-value")
+	}
+	if cookies[0].Name != "session" {
+		t.Errorf("cookie name = %q, want %q", cookies[0].Name, "session")
 	}
 }

--- a/types/logger.go
+++ b/types/logger.go
@@ -16,9 +16,9 @@ type LoggerConfig struct {
 	// "debug"
 	LoggerLevel          string `yaml:"loggerLevel" json:"loggerLevel"`
 	LoggerFileName       string `yaml:"loggerFileName" json:"loggerFileName"`
-	LoggerFileMaxSize    int    `yaml:"LoggerFileMaxSize" json:"loggerFileMaxSize"`
-	LoggerFileMaxBackups int    `yaml:"LoggerFileMaxBackups" json:"loggerFileMaxBackups"`
-	LoggerFileMaxAge     int    `yaml:"LoggerFileMaxAge" json:"loggerFileMaxAge"`
+	LoggerFileMaxSize    int    `yaml:"loggerFileMaxSize" json:"loggerFileMaxSize"`
+	LoggerFileMaxBackups int    `yaml:"loggerFileMaxBackups" json:"loggerFileMaxBackups"`
+	LoggerFileMaxAge     int    `yaml:"loggerFileMaxAge" json:"loggerFileMaxAge"`
 	LoggerPrefix         string `yaml:"loggerPrefix" json:"loggerPrefix"`
 }
 

--- a/utils/str.go
+++ b/utils/str.go
@@ -2,7 +2,8 @@ package utils
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 	"text/template"
 )
 
@@ -10,7 +11,11 @@ func RandomString(length int) string {
 	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	result := make([]rune, length)
 	for i := range result {
-		result[i] = letters[rand.Intn(len(letters))]
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			panic("crypto/rand failed: " + err.Error())
+		}
+		result[i] = letters[n.Int64()]
 	}
 	return string(result)
 }

--- a/utils/str_test.go
+++ b/utils/str_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+)
+
+func TestRandomString(t *testing.T) {
+	t.Run("correct length", func(t *testing.T) {
+		for _, n := range []int{0, 1, 8, 16, 64} {
+			got := RandomString(n)
+			if len(got) != n {
+				t.Errorf("RandomString(%d) length = %d, want %d", n, len(got), n)
+			}
+		}
+	})
+
+	t.Run("only letters", func(t *testing.T) {
+		s := RandomString(200)
+		for _, r := range s {
+			if !unicode.IsLetter(r) {
+				t.Errorf("RandomString produced non-letter character: %q", r)
+			}
+		}
+	})
+
+	t.Run("uniqueness", func(t *testing.T) {
+		seen := make(map[string]struct{}, 20)
+		for range 20 {
+			s := RandomString(16)
+			seen[s] = struct{}{}
+		}
+		// Expect at least 10 unique strings out of 20 (collision is astronomically unlikely)
+		if len(seen) < 10 {
+			t.Errorf("RandomString produced too many collisions: %d unique out of 20", len(seen))
+		}
+	})
+
+	t.Run("only ascii letters", func(t *testing.T) {
+		const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		s := RandomString(100)
+		for _, r := range s {
+			if !strings.ContainsRune(alphabet, r) {
+				t.Errorf("RandomString produced character outside alphabet: %q", r)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Four code quality refactors in a single branch:

- **#268** — Replace `math/rand` with `crypto/rand` in `RandomString` for cryptographic security. Add `utils/str_test.go` with length, alphabet, and uniqueness tests.
- **#276** — Fix `LoggerConfig` YAML tags: `LoggerFileMaxSize`, `LoggerFileMaxBackups`, and `LoggerFileMaxAge` had PascalCase YAML tags while all other fields used camelCase. Normalised to camelCase.
- **#269** — Extract cookie decryption external dependencies behind interfaces. Introduce `KeychainReader` and `SQLiteQuerier` interfaces; add `ReadChromeCookiesWithDeps` for DI. Add integration-style tests using stub implementations.
- **#270** — Replace manual drag polling loop (`for` + `time.Sleep`) with `page.Mouse.MoveLinear`, rod's built-in linear interpolation. Switch press/release to `Mouse.Down`/`Mouse.Up`. Remove the now-unused `dragStepDelay` constant.

## Test plan

- [x] `go test ./...` passes (all packages: tools, types, utils)
- [x] `go build ./...` compiles cleanly
- [x] New tests added for `RandomString` (utils/str_test.go)
- [x] New tests added for `ReadChromeCookiesWithDeps` (types/cookies_test.go)

Closes #268, Closes #276, Closes #269, Closes #270