### PR TITLE
fix: return error when CSS selector matches no elements

### DIFF
--- a/tools/constants.go
+++ b/tools/constants.go
@@ -33,6 +33,10 @@ const (
 
 	// defaultFormContainerTimeout is the max time to wait for a modal form container to appear.
 	defaultFormContainerTimeout = 5 * time.Second
+
+	// defaultSelectorTimeout is the max time to wait for a CSS selector to match an element.
+	// Without a timeout, page.Element() polls indefinitely and the tool hangs forever.
+	defaultSelectorTimeout = 10 * time.Second
 )
 
 // Default parameter values for tool options.

--- a/tools/drag.go
+++ b/tools/drag.go
@@ -33,7 +33,7 @@ var (
 func resolvePosition(page *rod.Page, args map[string]interface{}, selectorKey, xKey, yKey string) (float64, float64, error) {
 	selector := getOptionalStringArg(args, selectorKey)
 	if selector != "" {
-		el, err := page.Element(selector)
+		el, err := page.Timeout(defaultSelectorTimeout).Element(selector)
 		if err != nil {
 			return 0, 0, fmt.Errorf("find element %q: %w", selector, err)
 		}

--- a/tools/frames.go
+++ b/tools/frames.go
@@ -83,6 +83,7 @@ var (
 // resolvePiercingSelector handles selectors with >>> (shadow DOM piercing combinator).
 // For example: "my-component >>> .inner-button" traverses into shadow roots.
 // Returns the element found after piercing through shadow roots.
+// The page must already have a timeout set by the caller to prevent indefinite hangs.
 func resolvePiercingSelector(page *rod.Page, selector string) (*rod.Element, error) {
 	parts := strings.Split(selector, ">>>")
 	if len(parts) == 1 {

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -95,14 +95,16 @@ func resolveSnapshotElement(rodCtx *types.Context, args map[string]interface{}, 
 
 // resolveBySelector locates an element using a CSS selector.
 // Supports shadow DOM piercing via >>> combinator (e.g. "my-component >>> .inner").
+// Returns an error if no element is found within defaultSelectorTimeout.
 func resolveBySelector(page *rod.Page, selector string) (*rod.Element, error) {
 	var element *rod.Element
 	var err error
 
+	timedPage := page.Timeout(defaultSelectorTimeout)
 	if strings.Contains(selector, ">>>") {
-		element, err = resolvePiercingSelector(page, selector)
+		element, err = resolvePiercingSelector(timedPage, selector)
 	} else {
-		element, err = page.Element(selector)
+		element, err = timedPage.Element(selector)
 	}
 	if err != nil {
 		info, infoErr := page.Info()

--- a/tools/html.go
+++ b/tools/html.go
@@ -43,8 +43,8 @@ var (
 				}
 				html = r.Value.Str()
 			} else {
-				// Element HTML
-				el, err := page.Element(selector)
+				// Element HTML — use timeout so missing selectors return an error instead of hanging.
+				el, err := page.Timeout(defaultSelectorTimeout).Element(selector)
 				if err != nil {
 					return toolErr(fmt.Sprintf("find element %q", selector), err)
 				}

--- a/tools/input.go
+++ b/tools/input.go
@@ -174,7 +174,7 @@ var (
 					return toolErr("upload files", err)
 				}
 			} else {
-				element, err = page.Element(selector)
+				element, err = page.Timeout(defaultSelectorTimeout).Element(selector)
 				if err != nil {
 					return toolErr("find file input "+selector, err)
 				}

--- a/tools/login.go
+++ b/tools/login.go
@@ -135,7 +135,7 @@ func parseLoginParams(args map[string]interface{}, cfg types.Config) (loginParam
 // If userSelector is empty, tries the provided selectors (or defaults) with optional scope prefix.
 func loginFillUsername(page *rod.Page, username, userSelector, scope string, selectors []string) error {
 	if userSelector != "" {
-		el, err := page.Element(userSelector)
+		el, err := page.Timeout(defaultSelectorTimeout).Element(userSelector)
 		if err != nil {
 			return fmt.Errorf("selector %q: %w", userSelector, err)
 		}
@@ -145,11 +145,14 @@ func loginFillUsername(page *rod.Page, username, userSelector, scope string, sel
 	if len(selectors) == 0 {
 		selectors = defaultUsernameSelectors
 	}
+	// Use a short probe timeout when trying multiple fallback selectors — each one
+	// should fail fast if not present rather than blocking the full defaultSelectorTimeout.
+	shortProbe := page.Timeout(2 * time.Second)
 	for _, sel := range selectors {
 		if scope != "" {
 			sel = scope + " " + sel
 		}
-		el, err := page.Element(sel)
+		el, err := shortProbe.Element(sel)
 		if err == nil {
 			if fillErr := loginSmartFill(el, username); fillErr == nil {
 				return nil
@@ -164,9 +167,10 @@ func loginFillUsername(page *rod.Page, username, userSelector, scope string, sel
 
 // loginFillPassword finds and fills the password field, trying a scoped selector as fallback.
 func loginFillPassword(page *rod.Page, password, passSelector, scope string) error {
-	el, err := page.Element(passSelector)
+	timedPage := page.Timeout(defaultSelectorTimeout)
+	el, err := timedPage.Element(passSelector)
 	if err != nil && scope != "" {
-		el, err = page.Element(scope + " " + passSelector)
+		el, err = timedPage.Element(scope + " " + passSelector)
 	}
 	if err != nil {
 		return fmt.Errorf("selector %q: %w", passSelector, err)
@@ -176,9 +180,10 @@ func loginFillPassword(page *rod.Page, password, passSelector, scope string) err
 
 // loginSubmit finds and clicks the submit button, trying a scoped selector as fallback.
 func loginSubmit(page *rod.Page, submitSelector, scope string) error {
-	el, err := page.Element(submitSelector)
+	timedPage := page.Timeout(defaultSelectorTimeout)
+	el, err := timedPage.Element(submitSelector)
 	if err != nil && scope != "" {
-		el, err = page.Element(scope + " " + submitSelector)
+		el, err = timedPage.Element(scope + " " + submitSelector)
 	}
 	if err != nil {
 		return fmt.Errorf("selector %q: %w", submitSelector, err)
@@ -188,7 +193,7 @@ func loginSubmit(page *rod.Page, submitSelector, scope string) error {
 
 // loginOpenTrigger clicks a trigger element and waits for the form container to appear.
 func loginOpenTrigger(page *rod.Page, triggerSelector, formContainer string) error {
-	triggerEl, err := page.Element(triggerSelector)
+	triggerEl, err := page.Timeout(defaultSelectorTimeout).Element(triggerSelector)
 	if err != nil {
 		return fmt.Errorf("find trigger %q: %w", triggerSelector, err)
 	}

--- a/tools/scroll_helpers.go
+++ b/tools/scroll_helpers.go
@@ -8,8 +8,9 @@ import (
 )
 
 // scrollToElement scrolls a CSS-selected element into view and returns its resulting position.
+// Uses defaultSelectorTimeout so the call fails fast if the selector matches no elements.
 func scrollToElement(page *rod.Page, selector string) (*mcp.CallToolResult, error) {
-	el, err := page.Element(selector)
+	el, err := page.Timeout(defaultSelectorTimeout).Element(selector)
 	if err != nil {
 		return toolErr(fmt.Sprintf("scroll to element %q", selector), err)
 	}


### PR DESCRIPTION
## Summary
- Add `defaultSelectorTimeout` (10 seconds) constant to cap how long `page.Element()` waits for a CSS selector match
- Apply timeout to all tool entry points that call `page.Element()` without an existing timeout guard
- For login fallback selectors (trying multiple defaults), use a 2-second short probe so each candidate fails fast

Closes #23

## Root Cause

Rod's `page.Element()` uses a polling loop with no default deadline — it waits until the element appears or the browser context is cancelled. MCP tool calls have no such cancellation, so a selector that matches zero elements causes the tool to hang indefinitely.

## Tools Fixed

- `rod_html` (direct `page.Element` call)
- `rod_click`, `rod_hover`, `rod_fill`, `rod_scroll` (element mode), `rod_selector`, and all tools using `resolveBySelector` via `helpers.go`
- `rod_drag` (selector-based source/target positions)
- `rod_scroll` (scroll-to-element helper)
- `rod_file_upload`
- `rod_login` (all internal helper functions: `loginFillUsername`, `loginFillPassword`, `loginSubmit`, `loginOpenTrigger`)
- Shadow DOM piercing (`resolvePiercingSelector`) — timeout propagated from caller

## Test plan
- [ ] `go test -race ./...` passes
- [ ] Manual test: `rod_html` with a selector that matches no elements returns an error within 10 seconds
- [ ] Existing tests still pass (selectors that DO match work normally)