### PR TITLE
fix: rod_evaluate awaits async function results (Closes #280)

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -703,10 +703,37 @@ func TestE2E_Evaluate(t *testing.T) {
 	h.initialize()
 	h.navigate("https://the-internet.herokuapp.com")
 
-	result := h.call("rod_evaluate", map[string]any{
-		"script": "() => document.title",
+	t.Run("sync_arrow", func(t *testing.T) {
+		result := h.call("rod_evaluate", map[string]any{
+			"script": "() => document.title",
+		})
+		assertContainsAny(t, result, "the-internet", "Internet")
 	})
-	assertContainsAny(t, result, "the-internet", "Internet")
+
+	// Regression test for issue #280: async functions and promise-returning
+	// scripts must serialize the resolved value, not the Promise reference.
+	// Before the fix the result was "{}" because the async arrow was treated
+	// as a bare expression that evaluated to a function reference.
+	t.Run("async_arrow_returns_resolved_value", func(t *testing.T) {
+		result := h.callWithTimeout("rod_evaluate", map[string]any{
+			"script": `async () => {
+				await new Promise(r => setTimeout(r, 50));
+				return { ok: true, count: 7 };
+			}`,
+		}, timeoutMedium)
+		assertContains(t, result, `"ok":true`)
+		assertContains(t, result, `"count":7`)
+	})
+
+	t.Run("async_arrow_returns_array", func(t *testing.T) {
+		result := h.callWithTimeout("rod_evaluate", map[string]any{
+			"script": `async () => {
+				await new Promise(r => setTimeout(r, 10));
+				return [1, 2, 3];
+			}`,
+		}, timeoutMedium)
+		assertContains(t, result, "[1,2,3]")
+	})
 }
 
 // TestE2E_Network tests network_requests, response_body, set_headers, intercept, and websocket.

--- a/tools/browser.go
+++ b/tools/browser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-rod/rod/lib/proto"
@@ -62,10 +63,9 @@ var (
 			}
 			// Wrap function expressions so they get invoked, not just defined.
 			// e.g. "() => document.title" becomes "(() => document.title)()"
-			expression := script
-			if len(script) > 0 && (script[0] == '(' || len(script) > 8 && script[:8] == "function") {
-				expression = "(" + script + ")()"
-			}
+			// Also handles async variants — without wrapping, "async () => ..." evaluates
+			// to a function reference and serializes as "{}" via ReturnByValue.
+			expression := wrapFunctionExpression(script)
 			r, err := proto.RuntimeEvaluate{
 				Expression:            expression,
 				ObjectGroup:           "console",
@@ -264,3 +264,47 @@ var (
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}
 )
+
+// wrapFunctionExpression wraps a bare function expression so the CDP
+// Runtime.evaluate call invokes it instead of returning the function reference.
+// Without this, scripts like "() => ..." or "async () => ..." evaluate to a
+// function value which serializes as "{}" under ReturnByValue.
+//
+// Recognised forms (after trimming leading whitespace):
+//   - "(...)" or "(...) => ..."
+//   - "function ..." / "function (...) ..."
+//   - "async () => ..." / "async function ..."
+//
+// Anything else (a statement, a bare identifier, an already-invoked expression)
+// is returned unchanged.
+func wrapFunctionExpression(script string) string {
+	trimmed := strings.TrimLeft(script, " \t\n\r")
+	if trimmed == "" {
+		return script
+	}
+	isFunc := false
+	switch {
+	case trimmed[0] == '(':
+		isFunc = true
+	case strings.HasPrefix(trimmed, "function") &&
+		(len(trimmed) == len("function") || !isIdentChar(trimmed[len("function")])):
+		isFunc = true
+	case strings.HasPrefix(trimmed, "async") &&
+		len(trimmed) > len("async") && !isIdentChar(trimmed[len("async")]):
+		// "async (" or "async function" or "async\t..." — anything where the
+		// next non-identifier char starts a function form.
+		isFunc = true
+	}
+	if !isFunc {
+		return script
+	}
+	return "(" + script + ")()"
+}
+
+// isIdentChar reports whether c can appear inside a JS identifier.
+// Used to ensure we match the "function" / "async" keyword and not a longer
+// identifier like "functionFoo" or "asyncify".
+func isIdentChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') || c == '_' || c == '$'
+}

--- a/tools/browser.go
+++ b/tools/browser.go
@@ -271,12 +271,15 @@ var (
 // function value which serializes as "{}" under ReturnByValue.
 //
 // Recognised forms (after trimming leading whitespace):
-//   - "(...)" or "(...) => ..."
+//   - "(...) => ..." (parenthesised arrow / grouped expression that is not
+//     already invoked at the top level)
 //   - "function ..." / "function (...) ..."
-//   - "async () => ..." / "async function ..."
+//   - "async (...) => ..." / "async function ..." (with optional whitespace
+//     between "async" and the function form)
 //
-// Anything else (a statement, a bare identifier, an already-invoked expression)
-// is returned unchanged.
+// Anything else — a statement, a bare identifier, an already-invoked IIFE
+// like "(() => 1)()", or a non-function expression starting with "async"
+// such as "async = 1" — is returned unchanged.
 func wrapFunctionExpression(script string) string {
 	trimmed := strings.TrimLeft(script, " \t\n\r")
 	if trimmed == "" {
@@ -285,15 +288,28 @@ func wrapFunctionExpression(script string) string {
 	isFunc := false
 	switch {
 	case trimmed[0] == '(':
-		isFunc = true
+		// Skip already-invoked IIFEs: "(...)(...)". Wrapping them would
+		// produce "((...)(...))()", which evaluates the IIFE and then tries
+		// to call its result — almost always a TypeError.
+		isFunc = !isInvokedExpression(trimmed)
 	case strings.HasPrefix(trimmed, "function") &&
 		(len(trimmed) == len("function") || !isIdentChar(trimmed[len("function")])):
 		isFunc = true
-	case strings.HasPrefix(trimmed, "async") &&
-		len(trimmed) > len("async") && !isIdentChar(trimmed[len("async")]):
-		// "async (" or "async function" or "async\t..." — anything where the
-		// next non-identifier char starts a function form.
-		isFunc = true
+	case strings.HasPrefix(trimmed, "async"):
+		// Only treat as a function form if "async" is followed (after optional
+		// whitespace) by "(" — async arrow — or "function" — async function
+		// expression. Bare "async = 1", "async + 1", or "asyncify()" must not
+		// match, or wrapping produces invalid JS / changes semantics.
+		rest := strings.TrimLeft(trimmed[len("async"):], " \t\n\r")
+		switch {
+		case rest == "":
+			// just the keyword on its own — leave alone.
+		case rest[0] == '(':
+			isFunc = true
+		case strings.HasPrefix(rest, "function") &&
+			(len(rest) == len("function") || !isIdentChar(rest[len("function")])):
+			isFunc = true
+		}
 	}
 	if !isFunc {
 		return script
@@ -301,9 +317,45 @@ func wrapFunctionExpression(script string) string {
 	return "(" + script + ")()"
 }
 
-// isIdentChar reports whether c can appear inside a JS identifier.
-// Used to ensure we match the "function" / "async" keyword and not a longer
-// identifier like "functionFoo" or "asyncify".
+// isInvokedExpression reports whether a string starting with '(' is an
+// already-invoked expression, i.e. the matching ')' is followed (after
+// optional whitespace) by '('. Examples that return true:
+//
+//	"(() => 1)()", "(function () { ... })()", "(x)(y, z)"
+//
+// Examples that return false:
+//
+//	"(() => 1)", "(x + y)", "() => x"
+//
+// Limitation: this is a simple paren-depth scanner; it does not skip
+// parentheses inside string literals, regex literals, or comments. For
+// rod_evaluate inputs that's acceptable — the inputs are short scripts and
+// the wrapping decision only changes behaviour for unusual edge cases.
+func isInvokedExpression(s string) bool {
+	if len(s) == 0 || s[0] != '(' {
+		return false
+	}
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				rest := strings.TrimLeft(s[i+1:], " \t\n\r")
+				return len(rest) > 0 && rest[0] == '('
+			}
+		}
+	}
+	return false
+}
+
+// isIdentChar reports whether c can appear inside a JS identifier, using an
+// ASCII-only heuristic. JS identifiers also allow many Unicode code points,
+// but here this only needs to distinguish keywords ("function" / "async")
+// from longer identifiers that share their prefix ("functionFoo",
+// "asyncify"), and ASCII coverage is enough for that.
 func isIdentChar(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
 		(c >= '0' && c <= '9') || c == '_' || c == '$'

--- a/tools/browser_test.go
+++ b/tools/browser_test.go
@@ -17,7 +17,7 @@ func TestWrapFunctionExpression(t *testing.T) {
 			want: "(() => document.title)()",
 		},
 		{
-			name: "named function expression",
+			name: "anonymous function expression",
 			in:   "function () { return 1 }",
 			want: "(function () { return 1 })()",
 		},
@@ -57,9 +57,44 @@ func TestWrapFunctionExpression(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "already-invoked IIFE is wrapped (existing behaviour)",
+			name: "already-invoked IIFE is left alone",
 			in:   "(() => 1)()",
-			want: "((() => 1)())()",
+			want: "(() => 1)()",
+		},
+		{
+			name: "already-invoked IIFE with arguments is left alone",
+			in:   "(function () { return 1 })()",
+			want: "(function () { return 1 })()",
+		},
+		{
+			name: "parenthesised arrow that is not invoked is wrapped",
+			in:   "(() => 1)",
+			want: "((() => 1))()",
+		},
+		{
+			name: "async assignment is not wrapped",
+			in:   "async = 1",
+			want: "async = 1",
+		},
+		{
+			name: "async followed by non-function token is not wrapped",
+			in:   "async + 1",
+			want: "async + 1",
+		},
+		{
+			name: "async with extra whitespace before arrow is wrapped",
+			in:   "async   () => 1",
+			want: "(async   () => 1)()",
+		},
+		{
+			name: "async with newline before function keyword is wrapped",
+			in:   "async\nfunction () { return 1 }",
+			want: "(async\nfunction () { return 1 })()",
+		},
+		{
+			name: "asyncFoo identifier is not wrapped",
+			in:   "asyncFoo()",
+			want: "asyncFoo()",
 		},
 	}
 

--- a/tools/browser_test.go
+++ b/tools/browser_test.go
@@ -1,0 +1,74 @@
+package tools
+
+import "testing"
+
+// TestWrapFunctionExpression exercises the script-wrapping logic used by
+// rod_evaluate. Without wrapping, function expressions evaluate to a function
+// reference and serialize as "{}" via ReturnByValue — see issue #280.
+func TestWrapFunctionExpression(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "arrow function in parens",
+			in:   "() => document.title",
+			want: "(() => document.title)()",
+		},
+		{
+			name: "named function expression",
+			in:   "function () { return 1 }",
+			want: "(function () { return 1 })()",
+		},
+		{
+			name: "async arrow function (issue #280)",
+			in:   "async () => { return { ok: true } }",
+			want: "(async () => { return { ok: true } })()",
+		},
+		{
+			name: "async function expression",
+			in:   "async function () { return 1 }",
+			want: "(async function () { return 1 })()",
+		},
+		{
+			name: "leading whitespace before async arrow",
+			in:   "  async () => 1",
+			want: "(  async () => 1)()",
+		},
+		{
+			name: "bare expression is left alone",
+			in:   "document.title",
+			want: "document.title",
+		},
+		{
+			name: "identifier that starts with async is not wrapped",
+			in:   "asyncify()",
+			want: "asyncify()",
+		},
+		{
+			name: "identifier that starts with function is not wrapped",
+			in:   "functionFoo()",
+			want: "functionFoo()",
+		},
+		{
+			name: "empty script is left alone",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "already-invoked IIFE is wrapped (existing behaviour)",
+			in:   "(() => 1)()",
+			want: "((() => 1)())()",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapFunctionExpression(tt.in)
+			if got != tt.want {
+				t.Errorf("wrapFunctionExpression(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Symptom

`rod_evaluate` returned `Evaluate code successfully with result: {}` for any script that started with `async`, e.g.:

```js
async () => {
  const r = await fetch('/foo');
  return { status: r.status };
}
```

The fetch fired (visible in the network tab) but the resolved value was dropped. Synchronous scripts using the same shape worked correctly. Filed as #280.

## Root cause

The function-wrapping heuristic in the `rod_evaluate` handler only recognised scripts that started with `(` or `function`:

```go
if len(script) > 0 && (script[0] == '(' || len(script) > 8 && script[:8] == "function") {
    expression = "(" + script + ")()"
}
```

For `async () => { ... }` neither branch matched, so the raw script text was sent as the CDP `Runtime.evaluate` expression. That parses as a bare arrow-function expression, which evaluates to a function value — and a function serialises as `{}` under `ReturnByValue: true`. `AwaitPromise: true` was already set, but it never had a promise to await because the function was never invoked.

## Fix

Refactor the wrapping logic into `wrapFunctionExpression()` and extend it to recognise `async () => ...`, `async function ...`, and the same forms with leading whitespace. Identifier-prefix collisions like `asyncify()` or `functionFoo()` are left untouched (the keyword check requires a non-identifier byte after the keyword).

## Tests

- **Unit** — `tools/browser_test.go`: table-driven coverage of `wrapFunctionExpression` including async/sync arrow forms, function expressions, leading whitespace, and identifier-prefix collisions.
- **E2E** — `e2e/e2e_test.go`: extends `TestE2E_Evaluate` with `async_arrow_returns_resolved_value` and `async_arrow_returns_array` subtests. Both reproduce the `{}` bug against `main` (verified by stashing the fix and rerunning) and pass with the change.

Full unit suite (`go test ./...`) and full e2e suite (`go test -tags=e2e ./e2e/...`) both green locally.

Closes #280