### PR TITLE
fix: default config path uses XDG_CONFIG_HOME instead of cwd (Closes #283)

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -35,7 +35,7 @@ func RunCmd() (*SubCfg, error) {
 			&cli.StringFlag{
 				Name:        "config",
 				Aliases:     []string{"c"},
-				Usage:       "use to set Rod MCP Server's config file path, file name is `rod-mcp.yaml`",
+				Usage:       "path to config file (default: $XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml, or ~/.config/rod-mcp/rod-mcp.yaml)",
 				Destination: &subConfig.ConfigPath,
 			}, &cli.StringFlag{
 				Name:        "cdp-endpoint",

--- a/types/config.go
+++ b/types/config.go
@@ -22,9 +22,10 @@ func DefaultConfigPath() string {
 	if configHome == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			// Fallback: use "~/.config" relative to cwd as last resort (should
-			// never happen in practice).
-			configHome = filepath.Join(".", ".config")
+			// os.UserHomeDir should never fail in normal operation; log and use a
+			// tmp-based fallback so we still avoid writing into the caller's cwd.
+			log.Warnf("could not determine home directory (%v); using os.TempDir for config", err)
+			configHome = filepath.Join(os.TempDir(), ".config")
 		} else {
 			configHome = filepath.Join(home, ".config")
 		}
@@ -106,7 +107,11 @@ var (
 // It creates any missing parent directories. If the file already exists, it is a no-op.
 func InitDefaultConfig() error {
 	defaultConfigPath := DefaultConfigPath()
-	if exist, _ := utils.PathExists(defaultConfigPath); exist {
+	exist, err := utils.PathExists(defaultConfigPath)
+	if err != nil {
+		log.Warnf("checking config path %s: %v", defaultConfigPath, err)
+	}
+	if exist {
 		return nil
 	}
 
@@ -119,6 +124,7 @@ func InitDefaultConfig() error {
 	if err != nil {
 		return fmt.Errorf("create default config %s: %w", defaultConfigPath, err)
 	}
+	defer f.Close()
 
 	encoder := yaml.NewEncoder(f)
 	defer encoder.Close()

--- a/types/config.go
+++ b/types/config.go
@@ -17,20 +17,36 @@ const ConfigName = "rod-mcp.yaml"
 // (or ~/.config when XDG_CONFIG_HOME is not set). It never references the
 // current working directory, so rod-mcp can be invoked from any directory
 // without polluting the caller's working tree.
+//
+// XDG_CONFIG_HOME is only used when it is set to an absolute path; relative or
+// tilde-prefixed values are ignored and the home-directory fallback is used
+// instead (a non-absolute XDG_CONFIG_HOME would reintroduce cwd-relative paths).
 func DefaultConfigPath() string {
-	configHome := os.Getenv("XDG_CONFIG_HOME")
-	if configHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			// os.UserHomeDir should never fail in normal operation; log and use a
-			// tmp-based fallback so we still avoid writing into the caller's cwd.
-			log.Warnf("could not determine home directory (%v); using os.TempDir for config", err)
-			configHome = filepath.Join(os.TempDir(), ".config")
-		} else {
-			configHome = filepath.Join(home, ".config")
-		}
-	}
+	configHome := xdgConfigHome()
 	return filepath.Join(configHome, "rod-mcp", ConfigName)
+}
+
+// xdgConfigHome returns the config base directory to use, resolving the XDG
+// spec (XDG_CONFIG_HOME → $HOME/.config → os.TempDir fallback). It always
+// returns an absolute path.
+func xdgConfigHome() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		// Only accept absolute paths; discard relative or tilde-prefixed values
+		// that would make the config path cwd-relative.
+		if filepath.IsAbs(xdg) {
+			return xdg
+		}
+		log.Warnf("XDG_CONFIG_HOME=%q is not an absolute path; ignoring and using ~/.config instead", xdg)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// os.UserHomeDir should never fail in normal operation; use os.TempDir
+		// so we always return an absolute path and never pollute the cwd.
+		log.Warnf("could not determine home directory (%v); using os.TempDir for config", err)
+		return filepath.Join(os.TempDir(), ".config")
+	}
+	return filepath.Join(home, ".config")
 }
 
 // ImageResponsesMode controls whether inline base64 image data is included in tool results.
@@ -116,11 +132,14 @@ func InitDefaultConfig() error {
 	}
 
 	// Ensure the parent directory exists before creating the file.
-	if err := os.MkdirAll(filepath.Dir(defaultConfigPath), 0o750); err != nil {
+	// Use 0700 (owner-only) since the config may contain sensitive values
+	// such as authorization tokens in DomainHeaders.
+	if err := os.MkdirAll(filepath.Dir(defaultConfigPath), 0o700); err != nil {
 		return fmt.Errorf("create config dir %s: %w", filepath.Dir(defaultConfigPath), err)
 	}
 
-	f, err := os.Create(defaultConfigPath)
+	// Use 0600 (owner read/write only) for the same reason.
+	f, err := os.OpenFile(defaultConfigPath, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
 	if err != nil {
 		return fmt.Errorf("create default config %s: %w", defaultConfigPath, err)
 	}

--- a/types/config.go
+++ b/types/config.go
@@ -13,6 +13,25 @@ import (
 
 const ConfigName = "rod-mcp.yaml"
 
+// DefaultConfigPath returns the canonical config path under XDG_CONFIG_HOME
+// (or ~/.config when XDG_CONFIG_HOME is not set). It never references the
+// current working directory, so rod-mcp can be invoked from any directory
+// without polluting the caller's working tree.
+func DefaultConfigPath() string {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			// Fallback: use "~/.config" relative to cwd as last resort (should
+			// never happen in practice).
+			configHome = filepath.Join(".", ".config")
+		} else {
+			configHome = filepath.Join(home, ".config")
+		}
+	}
+	return filepath.Join(configHome, "rod-mcp", ConfigName)
+}
+
 // ImageResponsesMode controls whether inline base64 image data is included in tool results.
 type ImageResponsesMode string
 
@@ -83,36 +102,40 @@ var (
 	}
 )
 
-// InitDefaultConfig Generate the default configuration file
+// InitDefaultConfig generates the default configuration file at DefaultConfigPath.
+// It creates any missing parent directories. If the file already exists, it is a no-op.
 func InitDefaultConfig() error {
-
-	// First, check if the configuration file exists at the default path. If it exists, do not generate the default configuration file.
-	defaultConfigPath := filepath.Join("./", ConfigName)
+	defaultConfigPath := DefaultConfigPath()
 	if exist, _ := utils.PathExists(defaultConfigPath); exist {
 		return nil
 	}
 
-	// if default config file not exist, create it
-	defaultConfig, err := os.Create(defaultConfigPath)
-	if err != nil {
-		return err
+	// Ensure the parent directory exists before creating the file.
+	if err := os.MkdirAll(filepath.Dir(defaultConfigPath), 0o750); err != nil {
+		return fmt.Errorf("create config dir %s: %w", filepath.Dir(defaultConfigPath), err)
 	}
 
-	encoder := yaml.NewEncoder(defaultConfig)
+	f, err := os.Create(defaultConfigPath)
+	if err != nil {
+		return fmt.Errorf("create default config %s: %w", defaultConfigPath, err)
+	}
+
+	encoder := yaml.NewEncoder(f)
 	defer encoder.Close()
 
-	err = encoder.Encode(DefaultConfig)
-	if err != nil {
-		return err
+	if err := encoder.Encode(DefaultConfig); err != nil {
+		return fmt.Errorf("write default config %s: %w", defaultConfigPath, err)
 	}
 	return nil
 }
 
-// LoadConfig Actually load the configuration file
-// if ConfigPath is empty, generate the default configuration file in the current directory
+// LoadConfig loads the configuration file at configPath.
+// When configPath is empty it uses DefaultConfigPath() (XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml),
+// creating the file with built-in defaults if it does not exist yet.
+// The resolved config path is logged at startup so users always know where rod-mcp reads config from.
 func LoadConfig(configPath string) (*Config, error) {
 	if configPath == "" {
-		configPath = filepath.Join("./", ConfigName)
+		configPath = DefaultConfigPath()
 		if err := InitDefaultConfig(); err != nil {
 			return nil, fmt.Errorf("init default config %s: %w", configPath, err)
 		}
@@ -125,10 +148,12 @@ func LoadConfig(configPath string) (*Config, error) {
 	}
 
 	if !exist {
-		log.Warnf("config file %s not found, using defaults", configPath)
+		log.Infof("config file not found at %s, using built-in defaults", configPath)
 		config := DefaultConfig
 		return &config, nil
 	}
+
+	log.Infof("loading config from %s", configPath)
 
 	file, err := os.Open(configPath)
 	if err != nil {

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -178,5 +179,69 @@ func TestGetHeadersForURL(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestDefaultConfigPathNeverUsesCwd verifies that DefaultConfigPath never returns
+// a path under the current working directory. Regression test for #283.
+func TestDefaultConfigPathNeverUsesCwd(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+
+	got := DefaultConfigPath()
+	if strings.HasPrefix(got, cwd) {
+		t.Errorf("DefaultConfigPath() = %q starts with cwd %q; must not write into the caller's working directory", got, cwd)
+	}
+}
+
+// TestLoadConfigDoesNotPolluteCwd verifies that calling LoadConfig with an empty
+// configPath (the no-flag default) creates no files in the current working directory.
+// Regression test for #283: rod-mcp was writing rod-mcp.yaml into cwd.
+func TestLoadConfigDoesNotPolluteCwd(t *testing.T) {
+	// Use a temp dir as our synthetic "project repo" cwd so we can check it cleanly.
+	fakeCwd := t.TempDir()
+
+	// Point XDG_CONFIG_HOME at a separate temp dir so InitDefaultConfig has somewhere
+	// to write without touching the user's real ~/.config.
+	xdgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+
+	// Change the process working directory to fakeCwd for the duration of the test.
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	if err := os.Chdir(fakeCwd); err != nil {
+		t.Fatalf("os.Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origWd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	// LoadConfig with empty path must not drop any file in fakeCwd.
+	if _, err := LoadConfig(""); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	entries, err := os.ReadDir(fakeCwd)
+	if err != nil {
+		t.Fatalf("os.ReadDir: %v", err)
+	}
+	if len(entries) > 0 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("LoadConfig wrote %d file(s) into cwd %q: %v", len(entries), fakeCwd, names)
+	}
+
+	// The config file should have been written under XDG_CONFIG_HOME instead.
+	wantPath := filepath.Join(xdgDir, "rod-mcp", ConfigName)
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Errorf("expected default config at %q, got: %v", wantPath, err)
 	}
 }

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -184,15 +184,41 @@ func TestGetHeadersForURL(t *testing.T) {
 
 // TestDefaultConfigPathNeverUsesCwd verifies that DefaultConfigPath never returns
 // a path under the current working directory. Regression test for #283.
+//
+// The test changes cwd to a fresh temp dir so the assertion is unambiguous
+// regardless of what directory the test runner is invoked from. It uses
+// filepath.Rel rather than strings.HasPrefix to avoid false positives from
+// case-insensitive filesystems or "/tmp/foo" vs "/tmp/foobar" overlaps.
 func TestDefaultConfigPathNeverUsesCwd(t *testing.T) {
-	cwd, err := os.Getwd()
+	// Use an isolated temp dir as cwd so we know exactly what to check against.
+	fakeCwd := t.TempDir()
+	origWd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("os.Getwd: %v", err)
 	}
+	if err := os.Chdir(fakeCwd); err != nil {
+		t.Fatalf("os.Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origWd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	// Point XDG_CONFIG_HOME to a known absolute path outside fakeCwd.
+	xdgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
 
 	got := DefaultConfigPath()
-	if strings.HasPrefix(got, cwd) {
-		t.Errorf("DefaultConfigPath() = %q starts with cwd %q; must not write into the caller's working directory", got, cwd)
+
+	// filepath.Rel returns a path starting with ".." when got is outside fakeCwd.
+	// If it does NOT start with "..", got is inside (or equal to) fakeCwd.
+	rel, err := filepath.Rel(fakeCwd, got)
+	if err != nil {
+		t.Fatalf("filepath.Rel: %v", err)
+	}
+	if !strings.HasPrefix(rel, "..") {
+		t.Errorf("DefaultConfigPath() = %q is inside cwd %q (rel=%q); must not reference the caller's working directory", got, fakeCwd, rel)
 	}
 }
 
@@ -243,5 +269,24 @@ func TestLoadConfigDoesNotPolluteCwd(t *testing.T) {
 	wantPath := filepath.Join(xdgDir, "rod-mcp", ConfigName)
 	if _, err := os.Stat(wantPath); err != nil {
 		t.Errorf("expected default config at %q, got: %v", wantPath, err)
+	}
+}
+
+// TestDefaultConfigPathIgnoresRelativeXDG verifies that a relative XDG_CONFIG_HOME
+// is rejected and the home-directory fallback is used instead. Addresses the
+// Copilot review finding that a relative XDG path would reintroduce cwd-pollution.
+func TestDefaultConfigPathIgnoresRelativeXDG(t *testing.T) {
+	// Set XDG_CONFIG_HOME to a relative path — must be ignored.
+	t.Setenv("XDG_CONFIG_HOME", ".config")
+
+	got := DefaultConfigPath()
+	if !filepath.IsAbs(got) {
+		t.Errorf("DefaultConfigPath() = %q is not absolute; relative XDG_CONFIG_HOME must be ignored", got)
+	}
+	// The path must NOT start with cwd/.config.
+	cwd, _ := os.Getwd()
+	rel, _ := filepath.Rel(cwd, got)
+	if !strings.HasPrefix(rel, "..") {
+		t.Errorf("DefaultConfigPath() = %q appears to be inside cwd %q; relative XDG_CONFIG_HOME must be ignored", got, cwd)
 	}
 }


### PR DESCRIPTION
## Problem

When `rod-mcp` was launched without `--config`, it wrote `rod-mcp.yaml` into the current working directory. Any host process (Claude Code, Codex, router-mcp, an editor) that spawned rod-mcp from inside a repo would leave a stray config file in that repo's working tree, polluting `git status`.

## Solution

- `DefaultConfigPath()` now resolves to `$XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml` (falling back to `~/.config/rod-mcp/rod-mcp.yaml` when `XDG_CONFIG_HOME` is not set)
- `InitDefaultConfig` creates the parent directory with `os.MkdirAll` if it does not exist
- `LoadConfig` logs the resolved path on startup so users always know where rod-mcp reads config from
- `--config` flag usage text now documents the default XDG path
- Explicit `--config <path>` continues to work unchanged
- A stray `rod-mcp.yaml` in cwd is still loaded if present at an explicit path; the default write now goes to the XDG location

## Acceptance criteria

- [x] Running `rod-mcp` from any cwd does not create files there
- [x] An explicit `--config <path>` continues to work
- [x] Startup log line shows which config path was used
- [x] `--help` documents the default XDG path
- [x] Regression test: `TestLoadConfigDoesNotPolluteCwd` runs from a temp dir and asserts it remains empty
- [x] Regression test: `TestDefaultConfigPathNeverUsesCwd` asserts the returned path never starts with cwd

## Files changed

- `types/config.go` — `DefaultConfigPath()`, `InitDefaultConfig`, `LoadConfig`
- `types/config_test.go` — two regression tests
- `cmd.go` — updated `--config` flag usage text