### PR TITLE
feat(config): default config to $XDG_CONFIG_HOME/rod-mcp/ instead of CWD (closes #292)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ That's it. Your AI agent can now browse the web.
 ### CLI Flags
 
 ```
---config, -c       Path to config file (default: ./rod-mcp.yaml)
+--config, -c       Path to config file (default: $XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml, or ~/.config/rod-mcp/rod-mcp.yaml)
 --headless, -hl    Run browser without GUI
 --vision, -vs      Enable vision mode (coordinate-based tools)
 --compact-snapshot  Reduce snapshot size for fewer tokens
@@ -209,7 +209,7 @@ That's it. Your AI agent can now browse the web.
 
 ### Config File
 
-Create a `rod-mcp.yaml` (one is generated automatically on first run):
+Create a config at `$XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml` (or `~/.config/rod-mcp/rod-mcp.yaml`; one is generated automatically there on first run):
 
 ```yaml
 mode: text                    # text or vision

--- a/README_CN.md
+++ b/README_CN.md
@@ -123,7 +123,7 @@ go install github.com/aliwatters/rod-mcp@latest
 ### 命令行参数
 
 ```
---config, -c       配置文件路径（默认：./rod-mcp.yaml）
+--config, -c       配置文件路径（默认：$XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml，或 ~/.config/rod-mcp/rod-mcp.yaml）
 --headless, -hl    无界面模式运行浏览器
 --vision, -vs      启用视觉模式（基于坐标的工具）
 --compact-snapshot  压缩快照以减少 Token 使用
@@ -135,7 +135,7 @@ go install github.com/aliwatters/rod-mcp@latest
 
 ### 配置文件
 
-创建 `rod-mcp.yaml`（首次运行时自动生成）：
+在 `$XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml`（或 `~/.config/rod-mcp/rod-mcp.yaml`）创建配置文件（首次运行时会自动在该位置生成）：
 
 ```yaml
 mode: text                    # text 或 vision

--- a/types/config.go
+++ b/types/config.go
@@ -155,17 +155,41 @@ func InitDefaultConfig() error {
 }
 
 // LoadConfig loads the configuration file at configPath.
-// When configPath is empty it uses DefaultConfigPath() (XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml),
-// creating the file with built-in defaults if it does not exist yet.
+// When configPath is empty it first checks DefaultConfigPath() (XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml),
+// then ./rod-mcp.yaml for legacy compatibility. If neither exists, it creates
+// DefaultConfigPath() with built-in defaults.
 // The resolved config path is logged at startup so users always know where rod-mcp reads config from.
 func LoadConfig(configPath string) (*Config, error) {
 	if configPath == "" {
-		configPath = DefaultConfigPath()
-		if err := InitDefaultConfig(); err != nil {
-			return nil, fmt.Errorf("init default config %s: %w", configPath, err)
+		var err error
+		configPath, err = resolveDefaultConfigPath()
+		if err != nil {
+			return nil, err
 		}
 	}
 
+	return loadConfigFile(configPath)
+}
+
+func resolveDefaultConfigPath() (string, error) {
+	defaultConfigPath := DefaultConfigPath()
+	for _, candidate := range []string{defaultConfigPath, ConfigName} {
+		exist, err := utils.PathExists(candidate)
+		if err != nil {
+			return "", fmt.Errorf("check config file %s: %w", candidate, err)
+		}
+		if exist {
+			return candidate, nil
+		}
+	}
+
+	if err := InitDefaultConfig(); err != nil {
+		return "", fmt.Errorf("init default config %s: %w", defaultConfigPath, err)
+	}
+	return defaultConfigPath, nil
+}
+
+func loadConfigFile(configPath string) (*Config, error) {
 	// check if config file exist
 	exist, err := utils.PathExists(configPath)
 	if err != nil {

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -272,6 +272,95 @@ func TestLoadConfigDoesNotPolluteCwd(t *testing.T) {
 	}
 }
 
+func TestLoadConfigUsesLegacyCwdConfigWhenCanonicalMissing(t *testing.T) {
+	fakeCwd := t.TempDir()
+	xdgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	if err := os.Chdir(fakeCwd); err != nil {
+		t.Fatalf("os.Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origWd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	if err := os.WriteFile(filepath.Join(fakeCwd, ConfigName), []byte("mode: vision\nheadless: true\nserverName: Legacy Config\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.Mode != Vision {
+		t.Errorf("Mode = %q, want %q from legacy config", cfg.Mode, Vision)
+	}
+	if !cfg.Headless {
+		t.Error("Headless = false, want true from legacy config")
+	}
+	if cfg.ServerName != "Legacy Config" {
+		t.Errorf("ServerName = %q, want legacy config value", cfg.ServerName)
+	}
+
+	canonicalPath := filepath.Join(xdgDir, "rod-mcp", ConfigName)
+	if _, err := os.Stat(canonicalPath); !os.IsNotExist(err) {
+		t.Errorf("canonical config should not be created when legacy config exists, stat err: %v", err)
+	}
+}
+
+func TestLoadConfigPrefersCanonicalConfigOverLegacyCwdConfig(t *testing.T) {
+	fakeCwd := t.TempDir()
+	xdgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	if err := os.Chdir(fakeCwd); err != nil {
+		t.Fatalf("os.Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origWd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	if err := os.WriteFile(filepath.Join(fakeCwd, ConfigName), []byte("mode: vision\nheadless: true\nserverName: Legacy Config\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalPath := filepath.Join(xdgDir, "rod-mcp", ConfigName)
+	if err := os.MkdirAll(filepath.Dir(canonicalPath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(canonicalPath, []byte("mode: text\nheadless: false\nserverName: Canonical Config\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.Mode != Text {
+		t.Errorf("Mode = %q, want %q from canonical config", cfg.Mode, Text)
+	}
+	if cfg.Headless {
+		t.Error("Headless = true, want false from canonical config")
+	}
+	if cfg.ServerName != "Canonical Config" {
+		t.Errorf("ServerName = %q, want canonical config value", cfg.ServerName)
+	}
+}
+
 // TestDefaultConfigPathIgnoresRelativeXDG verifies that a relative XDG_CONFIG_HOME
 // is rejected and the home-directory fallback is used instead. Addresses the
 // Copilot review finding that a relative XDG path would reintroduce cwd-pollution.


### PR DESCRIPTION
## Summary

rod-mcp's first-run behavior dropped `rod-mcp.yaml` in CWD whenever invoked from a directory without an existing config. Every consumer repo (sift-mcp, router-mcp, gsuite-mcp, dotfiles, etc.) needed a gitignore bandaid for the stray file. This was the root-cause counterpart to the gitignore-bandaid pattern recently hit in sift-mcp PR #126 and router-mcp PR #63.

`cmd.go:38` already documents the intended default as `$XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml`. This PR aligns the implementation with the documented intent.

## Changes

- **`types/config.go`**: `LoadConfig("")` now resolves the default config in priority order:
  1. `$XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml` (or `~/.config/rod-mcp/rod-mcp.yaml`)
  2. `./rod-mcp.yaml` (legacy, read-only fallback for Docker mounts and repos that already commit one)

  If neither exists, the canonical XDG config is created. **First-run never writes to CWD again.**
- **`types/config_test.go`**: Tests for all three acceptance criteria — legacy fallback, canonical precedence, first-run no-CWD pollution (last one was already covered, retained).
- **`README.md` + `README_CN.md`**: `--config` default text and first-run prose updated to match cmd.go's usage string.
- **`Dockerfile`**: untouched. The container-internal `printf > rod-mcp.yaml` pattern is fine.

## Test plan

- [x] `go test ./types/...` — 227 tests pass, including 2 new tests
- [x] `go test ./...` — full suite (358 tests, 5 packages) passes
- [x] Manual: built binary, ran from clean CWD with isolated `XDG_CONFIG_HOME`, confirmed `./rod-mcp.yaml` NOT created and canonical XDG file IS created
- [x] Legacy back-compat: existing `./rod-mcp.yaml` still loads when canonical is absent

## Acceptance criteria (from #292)

- [x] First run from consumer repo does NOT drop `rod-mcp.yaml` in CWD
- [x] Canonical config created at `~/.config/rod-mcp/rod-mcp.yaml` (or `$XDG_CONFIG_HOME/...`) on first run
- [x] Existing `./rod-mcp.yaml` (Docker mount, legacy commit) still loads — no breaking change
- [x] README updated to match `cmd.go` usage string

closes #292
