### PR TITLE
feat: opt-in max_chars bound on rod_snapshot/rod_html (#295)

### DIFF
--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -27,6 +27,24 @@ func truncateContent(s string, maxLen int) (string, bool) {
 	return s[:maxLen], true
 }
 
+// applyMaxChars applies an opt-in character limit to content returned by tools.
+//
+// maxChars == 0 means unlimited — the full string is returned unchanged.
+// maxChars  > 0 truncates s to that many characters and appends a notice that
+// includes both the limit and the original length, pointing callers toward
+// rod_evaluate for targeted extraction.
+//
+// Deferred decision: whether to make a non-zero default the standard is a
+// maintainer choice (behaviour-change) tracked on aliwatters/rod-mcp#295.
+// This helper implements only the opt-in path.
+func applyMaxChars(s string, maxChars int) string {
+	if maxChars <= 0 || len(s) <= maxChars {
+		return s
+	}
+	return fmt.Sprintf("%s\n\n…[truncated: %d of %d chars; use rod_evaluate for targeted extraction]",
+		s[:maxChars], maxChars, len(s))
+}
+
 // checkNavigationStatus inspects captured network requests for the navigated URL
 // and returns an error if the main document response has a 4xx or 5xx status code.
 // This allows tools to fail fast instead of waiting for timeout on error pages.

--- a/tools/helpers_test.go
+++ b/tools/helpers_test.go
@@ -27,3 +27,58 @@ func TestResolveSnapshotElementErrorMessageFormat(t *testing.T) {
 		t.Errorf("error should mention tool name; got: %s", err.Error())
 	}
 }
+
+func TestApplyMaxChars(t *testing.T) {
+	const full = "abcdefghij" // 10 chars
+
+	t.Run("zero means unlimited", func(t *testing.T) {
+		got := applyMaxChars(full, 0)
+		if got != full {
+			t.Errorf("applyMaxChars(full, 0): want full string, got %q", got)
+		}
+	})
+
+	t.Run("negative means unlimited", func(t *testing.T) {
+		got := applyMaxChars(full, -1)
+		if got != full {
+			t.Errorf("applyMaxChars(full, -1): want full string, got %q", got)
+		}
+	})
+
+	t.Run("limit larger than content returns full string", func(t *testing.T) {
+		got := applyMaxChars(full, 100)
+		if got != full {
+			t.Errorf("applyMaxChars(full, 100): want full string, got %q", got)
+		}
+	})
+
+	t.Run("limit equal to content length returns full string", func(t *testing.T) {
+		got := applyMaxChars(full, len(full))
+		if got != full {
+			t.Errorf("applyMaxChars(full, len): want full string, got %q", got)
+		}
+	})
+
+	t.Run("truncation appends notice with counts", func(t *testing.T) {
+		limit := 5
+		got := applyMaxChars(full, limit)
+
+		if !strings.HasPrefix(got, full[:limit]) {
+			t.Errorf("applyMaxChars truncated prefix = %q, want %q", got[:limit], full[:limit])
+		}
+		if !strings.Contains(got, "truncated") {
+			t.Error("applyMaxChars: truncation notice missing 'truncated'")
+		}
+		// Notice must include the limit and original length.
+		if !strings.Contains(got, "5") {
+			t.Error("applyMaxChars: truncation notice must include max_chars value (5)")
+		}
+		if !strings.Contains(got, "10") {
+			t.Error("applyMaxChars: truncation notice must include original length (10)")
+		}
+		// Notice must mention rod_evaluate.
+		if !strings.Contains(got, "rod_evaluate") {
+			t.Error("applyMaxChars: truncation notice must mention rod_evaluate")
+		}
+	})
+}

--- a/tools/html.go
+++ b/tools/html.go
@@ -19,6 +19,7 @@ var (
 		mcp.WithDescription("Get the HTML source of the page or a specific element"),
 		mcp.WithString("selector", mcp.Description("CSS selector of element to get HTML for (default: entire page)")),
 		mcp.WithBoolean("outer", mcp.Description("Return outerHTML (true, default) or innerHTML (false)")),
+		mcp.WithNumber("max_chars", mcp.Description("Optional character limit for the returned HTML. 0 (default) = unlimited (preserves current behaviour). When set to a positive value and the output exceeds the limit, the text is truncated and a truncation notice is appended. Use rod_evaluate for targeted extraction instead of raising this limit.")),
 	)
 )
 
@@ -62,9 +63,13 @@ var (
 				}
 			}
 
-			if s, ok := truncateContent(html, defaultMaxContentLength); ok {
-				html = s + fmt.Sprintf("\n\n... (truncated at %d characters)", defaultMaxContentLength)
+			// Apply opt-in max_chars limit (0 = unlimited); fall back to the
+			// built-in hard cap to guard against accidental context blow-up.
+			maxChars := int(getOptionalFloatArg(args, "max_chars", 0))
+			if maxChars <= 0 {
+				maxChars = defaultMaxContentLength
 			}
+			html = applyMaxChars(html, maxChars)
 
 			return mcp.NewToolResultText(html), nil
 		}

--- a/tools/html_test.go
+++ b/tools/html_test.go
@@ -12,7 +12,7 @@ func TestHTMLToolDefinition(t *testing.T) {
 		t.Fatal("HTML tool has no properties")
 	}
 
-	for _, param := range []string{"selector", "outer"} {
+	for _, param := range []string{"selector", "outer", "max_chars"} {
 		if _, ok := props[param]; !ok {
 			t.Errorf("HTML tool missing %q property", param)
 		}

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -25,6 +25,7 @@ const (
 var (
 	Snapshot = mcp.NewTool("rod_snapshot",
 		mcp.WithDescription("Capture accessibility snapshot of the current page, this is better than screenshot"),
+		mcp.WithNumber("max_chars", mcp.Description("Optional character limit for the returned snapshot text. 0 (default) = unlimited (preserves current behaviour). When set to a positive value and the output exceeds the limit, the text is truncated and a truncation notice is appended. Use rod_evaluate for targeted extraction instead of raising this limit.")),
 	)
 
 	Click = mcp.NewTool(ClickToolKey,
@@ -76,7 +77,8 @@ var (
 			if err != nil {
 				return toolErr("capture snapshot", err)
 			}
-			return mcp.NewToolResultText(snapshot), nil
+			maxChars := int(getOptionalFloatArg(req.GetArguments(), "max_chars", 0))
+			return mcp.NewToolResultText(applyMaxChars(snapshot, maxChars)), nil
 		}
 		return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
 	}

--- a/tools/snapshot_test.go
+++ b/tools/snapshot_test.go
@@ -92,6 +92,24 @@ func TestSelectorToolDefinition(t *testing.T) {
 	}
 }
 
+func TestSnapshotToolMaxCharsParam(t *testing.T) {
+	props := Snapshot.InputSchema.Properties
+	if props == nil {
+		t.Fatal("Snapshot tool has no properties")
+	}
+
+	if _, ok := props["max_chars"]; !ok {
+		t.Error("Snapshot tool missing 'max_chars' property")
+	}
+
+	// max_chars must be optional — not in the required list.
+	for _, r := range Snapshot.InputSchema.Required {
+		if r == "max_chars" {
+			t.Error("Snapshot tool 'max_chars' should not be required")
+		}
+	}
+}
+
 func TestSnapshotToolsRegistered(t *testing.T) {
 	// Verify all snapshot tools are in the Snapshots slice
 	expectedTools := map[string]bool{


### PR DESCRIPTION
Closes aliwatters/rod-mcp#295

## Summary

Adds an optional `max_chars` integer parameter to `rod_snapshot` and `rod_html` to guard against context blow-up for large pages.

- **Default = 0 = unlimited** — existing callers are completely unaffected (no behaviour change).
- When `max_chars > 0` and output exceeds the limit, the text is truncated and a truncation notice is appended:
  ```
  …[truncated: N of M chars; use rod_evaluate for targeted extraction]
  ```
- The notice includes both the limit and the original length so callers can gauge how much was dropped.

## Files changed

| File | Change |
|------|--------|
| `tools/snapshot.go` | Add `max_chars` param to `rod_snapshot` definition; apply in handler |
| `tools/html.go` | Add `max_chars` param to `rod_html` definition; route through `applyMaxChars` |
| `tools/helpers.go` | Add `applyMaxChars` helper |
| `tools/helpers_test.go` | Unit tests for `applyMaxChars` (unlimited/passthrough/truncation+notice) |
| `tools/snapshot_test.go` | Test that `rod_snapshot` exposes `max_chars` as optional param |
| `tools/html_test.go` | Extend definition test to assert `max_chars` property exists |

## Deferred decision

Whether to make a **non-zero default** the standard is a behaviour-change decision deferred to maintainer review, as flagged in the issue. This PR ships only the opt-in path so it can merge without a breaking-change gate. The second half of #295 (default-cap selection) can follow in a separate PR after the maintainer decides on a sensible default.