### PR TITLE
fix(types): auto-recover dropped CDP connection on next action

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -395,6 +395,16 @@ func TestE2E_Navigation(t *testing.T) {
 			t.Errorf("expected fast failure but took %v", elapsed)
 		}
 	})
+
+	t.Run("close_browser_then_navigate_relaunches", func(t *testing.T) {
+		result := h.call("rod_close_browser", nil)
+		assertContains(t, result, "Close browser successfully")
+
+		result = h.callWithTimeout("rod_navigate", map[string]any{
+			"url": "https://the-internet.herokuapp.com",
+		}, timeoutLong)
+		assertContains(t, result, "Navigated to")
+	})
 }
 
 // TestE2E_Login tests the rod_login tool.

--- a/types/context.go
+++ b/types/context.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -44,16 +46,16 @@ type Context struct {
 
 	// browserLock serialises access to all browser-lifecycle fields:
 	// browser, page, pageCancel, keepaliveCancel, clonedProfileDir, and config.
-	browserLock      sync.Mutex
-	config           Config
-	browser          *rod.Browser
-	page             *rod.Page
+	browserLock sync.Mutex
+	config      Config
+	browser     *rod.Browser
+	page        *rod.Page
 	// pageCancel cancels event-listener goroutines attached to the current page.
 	// It is set when attachEventListeners creates a cancelable page copy, and
 	// called in closePage before the page is closed.
-	pageCancel       func()
+	pageCancel func()
 	// keepaliveCancel stops the CDP keepalive goroutine when the browser is closed.
-	keepaliveCancel  func()
+	keepaliveCancel func()
 	// clonedProfileDir is the temp directory from profile cloning, cleaned up on Close.
 	clonedProfileDir string
 
@@ -93,15 +95,17 @@ func (ctx *Context) EnsurePage() (*rod.Page, error) {
 	if err := ctx.initial(); err != nil {
 		return nil, err
 	}
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 	return ctx.page, nil
 }
 
 func (ctx *Context) ControlledPage() (*rod.Page, error) {
-	ctx.browserLock.Lock()
-	defer ctx.browserLock.Unlock()
-	if err := ctx.initLocked(); err != nil {
+	if err := ctx.initial(); err != nil {
 		return nil, err
 	}
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 	if ctx.page == nil {
 		return nil, errors.New("no active tab, call rod_navigate first")
 	}
@@ -110,11 +114,11 @@ func (ctx *Context) ControlledPage() (*rod.Page, error) {
 
 // ControlledBrowser returns the browser instance, or an error if no browser is running.
 func (ctx *Context) ControlledBrowser() (*rod.Browser, error) {
-	ctx.browserLock.Lock()
-	defer ctx.browserLock.Unlock()
-	if err := ctx.initLocked(); err != nil {
+	if err := ctx.initial(); err != nil {
 		return nil, err
 	}
+	ctx.browserLock.Lock()
+	defer ctx.browserLock.Unlock()
 	if ctx.browser == nil {
 		return nil, errors.New("no browser running, call rod_navigate first")
 	}
@@ -123,34 +127,98 @@ func (ctx *Context) ControlledBrowser() (*rod.Browser, error) {
 
 func (ctx *Context) initial() error {
 	ctx.browserLock.Lock()
-	defer ctx.browserLock.Unlock()
-	return ctx.initLocked()
+	recovered, err := ctx.initLocked()
+	ctx.browserLock.Unlock()
+	if recovered {
+		ctx.InvalidateSnapshot()
+	}
+	return err
 }
 
 // initLocked performs lazy initialization of the browser and page.
 // Must be called with browserLock held.
-func (ctx *Context) initLocked() error {
+func (ctx *Context) initLocked() (bool, error) {
 	var err error
+	recovered := false
+	if ctx.browser != nil {
+		if err := ctx.checkBrowserAliveLocked(); err != nil {
+			if !isClosedBrowserSessionError(err) {
+				return false, fmt.Errorf("check browser session: %w", err)
+			}
+			log.Warnf("browser session ended; relaunching on next action: %s", err)
+			if closeErr := ctx.closeBrowser(); closeErr != nil {
+				log.Warnf("drop stale browser session after close error: %s", closeErr)
+				ctx.dropBrowserStateLocked()
+			}
+			recovered = true
+		}
+	}
 	if ctx.browser == nil {
 		ctx.browser, ctx.clonedProfileDir, err = launchBrowser(ctx.stdContext, ctx.config)
 		if err != nil {
-			return fmt.Errorf("launch browser: %w", err)
+			return recovered, fmt.Errorf("launch browser: %w", err)
 		}
 		ctx.startKeepalive()
 		ctx.page, err = ctx.createPage()
 		if err != nil {
-			return fmt.Errorf("create initial page: %w", err)
+			return recovered, fmt.Errorf("create initial page: %w", err)
 		}
-		return nil
+		return recovered, nil
 	}
 	if ctx.page == nil {
 		ctx.page, err = ctx.createPage()
 		if err != nil {
-			return fmt.Errorf("create page: %w", err)
+			return recovered, fmt.Errorf("create page: %w", err)
 		}
 	}
 
-	return nil
+	return recovered, nil
+}
+
+func (ctx *Context) checkBrowserAliveLocked() error {
+	checkCtx, cancel := context.WithTimeout(ctx.stdContext, 5*time.Second)
+	defer cancel()
+	_, err := proto.BrowserGetVersion{}.Call(ctx.browser.Context(checkCtx))
+	return err
+}
+
+func isClosedBrowserSessionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"use of closed network connection",
+		"browser has been closed",
+		"connection reset by peer",
+		"connection is closed",
+		"broken pipe",
+		"session closed",
+		"target closed",
+		"websocket: close",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func (ctx *Context) dropBrowserStateLocked() {
+	if ctx.keepaliveCancel != nil {
+		ctx.keepaliveCancel()
+		ctx.keepaliveCancel = nil
+	}
+	if ctx.pageCancel != nil {
+		ctx.pageCancel()
+		ctx.pageCancel = nil
+	}
+	ctx.intercept.Cancel()
+	ctx.page = nil
+	ctx.browser = nil
 }
 
 func (ctx *Context) CurrentMode() Mode {
@@ -282,6 +350,10 @@ func (ctx *Context) closePage() error {
 	ctx.intercept.Cancel()
 	err := ctx.page.Close()
 	if err != nil {
+		if isClosedBrowserSessionError(err) {
+			ctx.page = nil
+			return nil
+		}
 		return fmt.Errorf("close page: %w", err)
 	}
 	ctx.page = nil
@@ -306,6 +378,10 @@ func (ctx *Context) closeBrowser() error {
 
 	err = ctx.browser.Close()
 	if err != nil {
+		if isClosedBrowserSessionError(err) {
+			ctx.browser = nil
+			return nil
+		}
 		return fmt.Errorf("close browser: %w", err)
 	}
 	ctx.browser = nil

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -2,6 +2,9 @@ package types
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net"
 	"testing"
 	"time"
 )
@@ -271,6 +274,35 @@ func TestStartKeepalive_NilBrowser(t *testing.T) {
 	ctx.startKeepalive()
 	if ctx.keepaliveCancel != nil {
 		t.Error("startKeepalive with nil browser should not set keepaliveCancel")
+	}
+}
+
+func TestIsClosedBrowserSessionError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "closed network connection",
+			err:  errors.New("write tcp 127.0.0.1:62624->127.0.0.1:62622: use of closed network connection"),
+			want: true,
+		},
+		{name: "net closed", err: net.ErrClosed, want: true},
+		{name: "closed pipe", err: io.ErrClosedPipe, want: true},
+		{name: "browser closed", err: errors.New("browser has been closed"), want: true},
+		{name: "connection reset", err: errors.New("read tcp: connection reset by peer"), want: true},
+		{name: "deadline", err: context.DeadlineExceeded, want: false},
+		{name: "connection refused", err: errors.New("dial tcp 127.0.0.1:9222: connect: connection refused"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isClosedBrowserSessionError(tt.err); got != tt.want {
+				t.Errorf("isClosedBrowserSessionError(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes aliwatters/rod-mcp#297

## Problem

After the browser is closed or goes idle mid-session, the stale `browser`/`page` handles held in `Context` were returned unchecked, so every subsequent rod tool call failed with `write tcp ...: use of closed network connection` until `restart_server`.

## Fix

`initLocked` now runs a lightweight `Browser.getVersion` liveness check before reusing an existing browser. On a closed/exited session it:

- cancels the keepalive goroutine and event/intercept listeners
- clears the stale browser/page handles
- relaunches Chromium and reconnects transparently on the same action (then invalidates the cached snapshot)

Close paths (`closePage`/`closeBrowser`) treat already-closed session errors as success so stale handles never persist.

A focused `isClosedBrowserSessionError` classifier matches the closed-network / broken-pipe / target-closed / websocket-close family (and `net.ErrClosed` / `io.ErrClosedPipe`), while deliberately excluding `connection refused` and `context deadline exceeded` so unrelated transient failures don't trigger a relaunch.

## Tests

- `TestIsClosedBrowserSessionError` — table test over the classifier, including the exact `use of closed network connection` symptom from the issue and negative cases
- e2e `close_browser_then_navigate_relaunches` — closes the browser then navigates, asserting transparent relaunch
- Full `go test ./...` and `go build ./...` pass