### PR TITLE
fix(browser): add launch backoff + retry cap to Chrome launch path

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Create a config at `$XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml` (or `~/.config/rod-mc
 
 ```yaml
 mode: text                    # text or vision
-headless: false               # run without GUI
+headless: true                # run without GUI
 browserBinPath: ""            # path to Chrome/Chromium (auto-detected)
 browserTempDir: ./rod/browser # browser profile directory
 noSandbox: false              # disable Chrome sandbox

--- a/README_CN.md
+++ b/README_CN.md
@@ -139,7 +139,7 @@ go install github.com/aliwatters/rod-mcp@latest
 
 ```yaml
 mode: text                    # text 或 vision
-headless: false               # 无界面模式
+headless: true                # 无界面模式
 browserBinPath: ""            # Chrome/Chromium 路径（自动检测）
 browserTempDir: ./rod/browser # 浏览器配置目录
 noSandbox: false              # 禁用 Chrome 沙箱

--- a/types/config.go
+++ b/types/config.go
@@ -108,7 +108,7 @@ var (
 
 	DefaultConfig = Config{
 		BrowserBinPath: "",
-		Headless:       false,
+		Headless:       true,
 		BrowserTempDir: DefaultBrowserTempDir,
 		NoSandbox:      false,
 		Proxy:          "",

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -29,6 +29,9 @@ func TestLoadConfigMergesDefaults(t *testing.T) {
 	if cfg.ImageResponses != ImageResponsesAllow {
 		t.Errorf("ImageResponses = %q, want %q (from DefaultConfig)", cfg.ImageResponses, ImageResponsesAllow)
 	}
+	if !cfg.Headless {
+		t.Error("Headless = false, want true from DefaultConfig")
+	}
 }
 
 func TestLoadConfigAcceptsCustomFilename(t *testing.T) {

--- a/types/context.go
+++ b/types/context.go
@@ -39,6 +39,10 @@ const (
 	cleanupRetryCount = 3
 	// cleanupRetryDelay is the wait between browser temp dir removal retries.
 	cleanupRetryDelay = 200 * time.Millisecond
+	// launchBackoffInitial is the first delay after a managed local browser launch failure.
+	launchBackoffInitial = time.Second
+	// launchBackoffMax caps managed local browser launch retry delays.
+	launchBackoffMax = 30 * time.Second
 )
 
 type Context struct {
@@ -58,6 +62,12 @@ type Context struct {
 	keepaliveCancel func()
 	// clonedProfileDir is the temp directory from profile cloning, cleaned up on Close.
 	clonedProfileDir string
+	// launchFailures tracks consecutive managed local Chrome launch failures.
+	launchFailures int
+	// nextLaunchAt is the earliest time a managed local Chrome launch may be retried.
+	nextLaunchAt time.Time
+	// lastLaunchErr is returned while managed local Chrome launch backoff is active.
+	lastLaunchErr error
 
 	// snapshotLock serialises access to the cached ARIA snapshot.
 	// Lock ordering: always acquire snapshotLock before browserLock if both are
@@ -80,6 +90,8 @@ type Context struct {
 	interceptLock sync.Mutex
 	intercept     *networkInterceptor
 }
+
+var browserLaunchNow = time.Now
 
 func NewContext(ctx context.Context, cfg Config) *Context {
 	return &Context{
@@ -140,29 +152,40 @@ func (ctx *Context) initial() error {
 func (ctx *Context) initLocked() (bool, error) {
 	var err error
 	recovered := false
+	launchReason := "initial browser launch"
 	if ctx.browser != nil {
 		if err := ctx.checkBrowserAliveLocked(); err != nil {
 			if !isClosedBrowserSessionError(err) {
 				return false, fmt.Errorf("check browser session: %w", err)
 			}
-			log.Warnf("browser session ended; relaunching on next action: %s", err)
+			log.Warnf("browser session ended or crashed; relaunching on next action: %s", err)
 			if closeErr := ctx.closeBrowser(); closeErr != nil {
 				log.Warnf("drop stale browser session after close error: %s", closeErr)
 				ctx.dropBrowserStateLocked()
 			}
 			recovered = true
+			launchReason = "relaunch after ended browser session"
 		}
 	}
 	if ctx.browser == nil {
-		ctx.browser, ctx.clonedProfileDir, err = launchBrowser(ctx.stdContext, ctx.config)
-		if err != nil {
-			return recovered, fmt.Errorf("launch browser: %w", err)
+		if err := ctx.launchBrowserLocked(launchReason); err != nil {
+			return recovered, err
 		}
 		ctx.startKeepalive()
 		ctx.page, err = ctx.createPage()
 		if err != nil {
+			pageErr := fmt.Errorf("create initial page: %w", err)
+			log.Warnf("browser launch failed after connect: reason=%s error=%s", launchReason, pageErr)
+			if ctx.isManagedLocalLaunchLocked() {
+				ctx.recordLaunchFailureLocked(launchReason, pageErr)
+			}
+			if closeErr := ctx.closeBrowser(); closeErr != nil {
+				log.Warnf("close browser after initial page failure: %s", closeErr)
+				ctx.dropBrowserStateLocked()
+			}
 			return recovered, fmt.Errorf("create initial page: %w", err)
 		}
+		ctx.recordLaunchSuccessLocked(launchReason)
 		return recovered, nil
 	}
 	if ctx.page == nil {
@@ -173,6 +196,96 @@ func (ctx *Context) initLocked() (bool, error) {
 	}
 
 	return recovered, nil
+}
+
+func (ctx *Context) isManagedLocalLaunchLocked() bool {
+	return ctx.config.CDPEndpoint == ""
+}
+
+func (ctx *Context) launchBrowserLocked(reason string) error {
+	if ctx.isManagedLocalLaunchLocked() {
+		if err := ctx.checkLaunchBackoffLocked(reason); err != nil {
+			return err
+		}
+	}
+
+	log.Infof(
+		"browser launch starting: reason=%s mode=%s headless=%t cdp=%t",
+		reason,
+		ctx.config.Mode,
+		ctx.config.Headless,
+		ctx.config.CDPEndpoint != "",
+	)
+	browser, clonedDir, err := launchBrowserFunc(ctx.stdContext, ctx.config)
+	if err != nil {
+		log.Warnf("browser launch failed: reason=%s error=%s", reason, err)
+		if ctx.isManagedLocalLaunchLocked() {
+			ctx.recordLaunchFailureLocked(reason, err)
+		}
+		return fmt.Errorf("launch browser: %w", err)
+	}
+	ctx.browser = browser
+	ctx.clonedProfileDir = clonedDir
+	return nil
+}
+
+func (ctx *Context) checkLaunchBackoffLocked(reason string) error {
+	if ctx.nextLaunchAt.IsZero() || !browserLaunchNow().Before(ctx.nextLaunchAt) {
+		return nil
+	}
+	remaining := ctx.nextLaunchAt.Sub(browserLaunchNow()).Round(time.Millisecond)
+	if remaining < 0 {
+		remaining = 0
+	}
+	log.Warnf(
+		"browser launch suppressed during backoff: reason=%s failures=%d retryAfter=%s remaining=%s",
+		reason,
+		ctx.launchFailures,
+		ctx.nextLaunchAt.Format(time.RFC3339),
+		remaining,
+	)
+	if ctx.lastLaunchErr == nil {
+		return fmt.Errorf("browser launch suppressed after %d failed attempt(s); retry after %s", ctx.launchFailures, ctx.nextLaunchAt.Format(time.RFC3339))
+	}
+	return fmt.Errorf("browser launch suppressed after %d failed attempt(s); retry after %s: %w", ctx.launchFailures, ctx.nextLaunchAt.Format(time.RFC3339), ctx.lastLaunchErr)
+}
+
+func (ctx *Context) recordLaunchFailureLocked(reason string, err error) {
+	ctx.launchFailures++
+	delay := launchBackoffInitial
+	for i := 1; i < ctx.launchFailures && delay < launchBackoffMax; i++ {
+		delay *= 2
+		if delay > launchBackoffMax {
+			delay = launchBackoffMax
+			break
+		}
+	}
+	ctx.nextLaunchAt = browserLaunchNow().Add(delay)
+	ctx.lastLaunchErr = err
+	log.Warnf(
+		"browser launch backoff set: reason=%s failures=%d delay=%s retryAfter=%s error=%s",
+		reason,
+		ctx.launchFailures,
+		delay,
+		ctx.nextLaunchAt.Format(time.RFC3339),
+		err,
+	)
+}
+
+func (ctx *Context) recordLaunchSuccessLocked(reason string) {
+	if ctx.launchFailures > 0 {
+		log.Infof("browser launch recovered: reason=%s previousFailures=%d", reason, ctx.launchFailures)
+	}
+	ctx.launchFailures = 0
+	ctx.nextLaunchAt = time.Time{}
+	ctx.lastLaunchErr = nil
+	log.Infof(
+		"browser launch succeeded: reason=%s mode=%s headless=%t cdp=%t",
+		reason,
+		ctx.config.Mode,
+		ctx.config.Headless,
+		ctx.config.CDPEndpoint != "",
+	)
 }
 
 func (ctx *Context) checkBrowserAliveLocked() error {

--- a/types/context_browser.go
+++ b/types/context_browser.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/charmbracelet/log"
 	"github.com/go-rod/rod"
@@ -13,12 +14,15 @@ import (
 	"github.com/aliwatters/rod-mcp/utils"
 )
 
+var launchBrowserFunc = launchBrowser
+
 // launchBrowser starts a new Chrome instance. When a user-data-dir is configured
 // and cloning is enabled (the default), the profile is cloned to a temp directory
 // whose path is returned as clonedDir so the caller can clean it up on exit.
 func launchBrowser(ctx context.Context, cfg Config) (browser *rod.Browser, clonedDir string, err error) {
 
 	if cfg.CDPEndpoint != "" {
+		log.Infof("browser launch: connecting to configured CDP endpoint")
 		b, err := controlBrowser(ctx, cfg.CDPEndpoint)
 		return b, "", err
 	}
@@ -41,10 +45,13 @@ func launchBrowser(ctx context.Context, cfg Config) (browser *rod.Browser, clone
 		return nil, "", err
 	}
 
+	log.Infof("browser launch: starting local Chrome headless=%t", cfg.Headless)
+	launchStart := time.Now()
 	controlUrl, err := browserLauncher.Launch()
 	if err != nil {
 		return nil, "", fmt.Errorf("launch local browser: %w", err)
 	}
+	log.Infof("browser launch: local Chrome returned CDP URL after %s", time.Since(launchStart).Round(time.Millisecond))
 	b, err := controlBrowser(ctx, controlUrl)
 	if err != nil {
 		return nil, "", err

--- a/types/context_browser_test.go
+++ b/types/context_browser_test.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestConfigureLauncherHeadlessFlag(t *testing.T) {
+	l, err := configureLauncher(context.Background(), Config{
+		Headless:       true,
+		BrowserBinPath: "/bin/echo",
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("configureLauncher: %v", err)
+	}
+	if !launcherArgsContain(l.FormatArgs(), "--headless") {
+		t.Fatalf("headless launcher args = %v, want --headless", l.FormatArgs())
+	}
+}
+
+func TestConfigureLauncherWindowedOmitsHeadlessFlag(t *testing.T) {
+	l, err := configureLauncher(context.Background(), Config{
+		Headless:       false,
+		BrowserBinPath: "/bin/echo",
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("configureLauncher: %v", err)
+	}
+	if launcherArgsContain(l.FormatArgs(), "--headless") {
+		t.Fatalf("windowed launcher args = %v, want no --headless", l.FormatArgs())
+	}
+}
+
+func launcherArgsContain(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want || strings.HasPrefix(arg, want+"=") {
+			return true
+		}
+	}
+	return false
+}

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -5,8 +5,13 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/go-rod/rod"
 )
 
 // newTestContext creates a Context with a default Config suitable for unit tests.
@@ -304,6 +309,107 @@ func TestIsClosedBrowserSessionError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInitial_LocalLaunchFailureBackoffSuppressesHotRetry(t *testing.T) {
+	ctx := newTestContext()
+	launchErr := errors.New("chrome exited during registration")
+	var attempts int32
+	withLaunchBrowserFunc(t, func(context.Context, Config) (*rod.Browser, string, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, "", launchErr
+	})
+
+	err := ctx.initial()
+	if err == nil {
+		t.Fatal("initial: expected launch error")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("launch attempts after first failure = %d, want 1", got)
+	}
+
+	err = ctx.initial()
+	if err == nil {
+		t.Fatal("initial during backoff: expected error")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("launch attempts during backoff = %d, want 1", got)
+	}
+	if !strings.Contains(err.Error(), "browser launch suppressed") {
+		t.Fatalf("backoff error = %q, want suppressed launch message", err.Error())
+	}
+	if !errors.Is(err, launchErr) {
+		t.Fatalf("backoff error should wrap previous launch error, got %v", err)
+	}
+}
+
+func TestInitial_LocalLaunchBackoffIsSerializedAcrossConcurrentCalls(t *testing.T) {
+	ctx := newTestContext()
+	launchErr := errors.New("chrome launch failed")
+	var attempts int32
+	withLaunchBrowserFunc(t, func(context.Context, Config) (*rod.Browser, string, error) {
+		atomic.AddInt32(&attempts, 1)
+		time.Sleep(20 * time.Millisecond)
+		return nil, "", launchErr
+	})
+
+	const callers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, callers)
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- ctx.initial()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err == nil {
+			t.Fatal("initial: expected all concurrent callers to receive errors")
+		}
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("concurrent launch attempts = %d, want 1", got)
+	}
+}
+
+func TestInitial_CDPEndpointFailuresDoNotUseManagedLaunchBackoff(t *testing.T) {
+	ctx := NewContext(context.Background(), Config{
+		Mode:        Text,
+		Headless:    true,
+		CDPEndpoint: "http://127.0.0.1:9222",
+	})
+	launchErr := errors.New("connect refused")
+	var attempts int32
+	withLaunchBrowserFunc(t, func(context.Context, Config) (*rod.Browser, string, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, "", launchErr
+	})
+
+	for i := 0; i < 2; i++ {
+		err := ctx.initial()
+		if err == nil {
+			t.Fatal("initial: expected CDP connection error")
+		}
+		if strings.Contains(err.Error(), "browser launch suppressed") {
+			t.Fatalf("CDP error unexpectedly used managed-launch backoff: %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("CDP launch attempts = %d, want 2", got)
+	}
+}
+
+func withLaunchBrowserFunc(t *testing.T, fn func(context.Context, Config) (*rod.Browser, string, error)) {
+	t.Helper()
+	prev := launchBrowserFunc
+	launchBrowserFunc = fn
+	t.Cleanup(func() {
+		launchBrowserFunc = prev
+	})
 }
 
 func TestClose_WithTempDir_Cleanup(t *testing.T) {


### PR DESCRIPTION
Closes aliwatters/rod-mcp#299

## Problem

Managed local Chrome launches had **no backoff and no retry cap**. When Chrome crash-looped (the issue captured 28 SIGABRT crashes in ~3 min — `EXC_CRASH (SIGABRT)` during `___RegisterApplication_block_invoke` @ HIServices on macOS), every tool call hit `initLocked()` with `ctx.browser == nil` and relaunched Chrome immediately in a tight loop, spawning dozens of processes. The session's tool calls eventually succeeded, so the storm was **invisible to the caller** — only the user-visible desktop crashing surfaced it.

This is distinct from PR #298, which fixed CDP *reconnect*. This is a *launch* crash-loop.

## Fix

- **Launch-guard state** on `Context` (under `browserLock`): consecutive failure count, `nextLaunchAt` gate, and the last launch error.
- **Exponential backoff** 1s → 30s cap between managed local launch attempts.
- **Surfaced error**: while the backoff window is active, `initial()` returns an explicit `browser launch suppressed after N failed attempt(s); retry after <ts>` error that **wraps the underlying launch failure** — no more silent relaunch.
- **Lifecycle logging** with reasons: launch start / success / failure / suppressed-during-backoff / relaunch-after-ended-session / crash detection.
- **Scope**: backoff applies only to managed local launches. CDP endpoints are user-managed and continue surfacing connection errors directly (covered by a test).
- **Default headless**: `DefaultConfig.Headless` flipped to `true`. The crash storm was a windowed Chrome (`RegisterApplication` is a GUI/windowserver path); headless is the correct default for an MCP server and reduces crash surface. README/README_CN updated to match.

## Tests

- No hot-retry: a failed launch is followed by a suppressed (non-launching) attempt during backoff.
- Serialized concurrency: 8 concurrent `initial()` callers → exactly 1 launch attempt, rest get backoff errors.
- CDP exempt: CDP-endpoint failures do not use managed-launch backoff.
- `configureLauncher` headless flag present/absent; headless default locked in `config_test.go`.

`go build ./...` clean, `go vet ./...` clean, full `go test ./...` green.