### PR TITLE
fix(input): type via InsertText + recover tool-handler panics (#302)

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -486,6 +486,29 @@ func TestE2E_Input(t *testing.T) {
 		assertContainsAny(t, result, "Press key", "pressed", "successfully")
 	})
 
+	t.Run("type_unicode", func(t *testing.T) {
+		h.navigate("https://the-internet.herokuapp.com")
+		text := "em—dash, é, “smart”, 👍"
+
+		result := h.call("rod_evaluate", map[string]any{
+			"script": `() => {
+				document.body.innerHTML = '<input id="unicode-input" />';
+				const input = document.querySelector("#unicode-input");
+				input.focus();
+				return document.activeElement === input ? "focused" : "not-focused";
+			}`,
+		})
+		assertContains(t, result, "focused")
+
+		result = h.call("rod_type", map[string]any{"text": text, "delay": 0})
+		assertContains(t, result, "Typed")
+
+		result = h.call("rod_evaluate", map[string]any{
+			"script": `() => document.querySelector("#unicode-input").value`,
+		})
+		assertContains(t, result, text)
+	})
+
 	t.Run("hover_via_evaluate", func(t *testing.T) {
 		h.navigate("https://the-internet.herokuapp.com/hovers")
 		result := h.call("rod_evaluate", map[string]any{

--- a/tools/input.go
+++ b/tools/input.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
-	"github.com/go-rod/rod/lib/input"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -16,9 +15,9 @@ import (
 )
 
 const (
-	PressKeyToolKey    = "rod_press"
-	TypeToolKey        = "rod_type"
-	FileUploadToolKey  = "rod_file_upload"
+	PressKeyToolKey   = "rod_press"
+	TypeToolKey       = "rod_type"
+	FileUploadToolKey = "rod_file_upload"
 )
 
 var (
@@ -120,9 +119,9 @@ var (
 			}
 			delay := time.Duration(delayMs * float64(time.Millisecond))
 
-			// Type each character with a delay between keystrokes.
+			// Insert each rune with a delay between text input events.
 			for _, ch := range text {
-				if err := page.Keyboard.Press(input.Key(ch)); err != nil {
+				if err := page.InsertText(string(ch)); err != nil {
 					return toolErr(fmt.Sprintf("type character %q", string(ch)), err)
 				}
 				if delay > 0 {

--- a/types/context.go
+++ b/types/context.go
@@ -349,8 +349,16 @@ func (ctx *Context) ClosePage() error {
 }
 
 func (ctx *Context) Execute(handlerFunc server.ToolHandlerFunc, handlerCallOpts ToolHandlerCallOpts) server.ToolHandlerFunc {
-	return func(stdCtx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		result, err := handlerFunc(stdCtx, request)
+	return func(stdCtx context.Context, request mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				log.Errorf("Tool handler panic: %v", recovered)
+				result = mcp.NewToolResultError(fmt.Sprintf("tool handler panic: %v", recovered))
+				err = nil
+			}
+		}()
+
+		result, err = handlerFunc(stdCtx, request)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // newTestContext creates a Context with a default Config suitable for unit tests.
@@ -270,6 +271,34 @@ func TestKeepaliveInterval(t *testing.T) {
 	// But not so frequent that it wastes resources.
 	if keepaliveInterval < 1*time.Minute {
 		t.Errorf("keepaliveInterval = %v, should be at least 1 minute", keepaliveInterval)
+	}
+}
+
+func TestExecuteRecoversHandlerPanic(t *testing.T) {
+	ctx := newTestContext()
+	handler := ctx.Execute(func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		panic("key not defined")
+	}, ToolHandlerCallOpts{})
+
+	result, err := handler(context.Background(), mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Execute returned nil result")
+	}
+	if !result.IsError {
+		t.Fatal("Execute panic recovery should return an MCP error result")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("Execute panic recovery returned no content")
+	}
+	text, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("Execute panic recovery content type = %T, want mcp.TextContent", result.Content[0])
+	}
+	if !strings.Contains(text.Text, "key not defined") {
+		t.Fatalf("Execute panic recovery text = %q, want panic value", text.Text)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #302. `rod_type` crashed the entire MCP server on any rune outside go-rod's keymap (em-dash, smart quotes, accented Latin, emoji, CJK), silently dropping the browser session, cookies, and headers for all subsequent calls.

## Root cause

`rod_type` pressed each character as a keyboard key via `page.Keyboard.Press(input.Key(ch))`. `input.Key.Info()` panics `"key not defined"` for any rune not in go-rod's keymap, and the unrecovered panic killed the process (clients saw `EOF` and reconnected with a fresh, logged-out browser context).

## Changes

- **`tools/input.go`** — type text via `page.InsertText` (CDP `Input.insertText`), which handles arbitrary Unicode and never panics. The per-rune loop and `delay` behavior are preserved; control keys (Enter/Tab/arrows) stay in `rod_press`. (`InsertText` is already the API used in `tools/vision.go`.)
- **`types/context.go`** — `Context.Execute` now recovers panics, **logs** the panic value, and converts it to an `mcp.NewToolResultError`, so a single bad input can no longer crash the server or destroy session state. Defense-in-depth for the whole tool surface.
- **`types/context_test.go`** — unit test asserting `Execute` recovers a handler panic into an MCP error result (runs in `go test ./...`).
- **`e2e/e2e_test.go`** — `TestE2E_Input/type_unicode` types and reads back a string containing em-dash, `é`, curly quotes, and an emoji (runs in the Chrome-equipped e2e CI job).

## Verification

- `go vet ./...`, `go build ./...`, `go test ./...` — all pass locally.
- `TestE2E_Input/type_unicode` passes headless locally (em—dash, é, "smart", 👍 round-trip through `rod_type`).
