### PR TITLE
test(e2e): default harness to headless; opt into headed via env (#303)

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -77,8 +77,10 @@ func newHarness(t *testing.T) *harness {
 
 	args := []string{"--no-banner"}
 
-	// In CI, run headless (no X server available)
-	if os.Getenv("CI") != "" {
+	// Default to headless: headed Chrome on macOS can abort in
+	// TransformProcessType under concurrent launches, and CI has no X server.
+	// Set ROD_MCP_E2E_HEADED only for local visual debugging.
+	if os.Getenv("ROD_MCP_E2E_HEADED") == "" {
 		args = append(args, "--headless")
 	}
 


### PR DESCRIPTION
## Summary

Fixes #303. Running the e2e suite locally on macOS triggered a Chrome **crash storm** (~10 `Google Chrome` SIGABRT aborts in minutes), ending in `browser launch backoff` failures.

## Root cause

`newHarness` only passed `--headless` when `CI` was set, so local runs (`CI` unset) launched **headed** Chrome. On macOS, headed Chrome aborts in `TransformProcessType`/`_RegisterApplication` under concurrent launches:

```
abort → HIServices _RegisterApplication → TransformProcessType
```

Headless Chrome never calls `TransformProcessType`, so it cannot hit this abort.

## Fix

Default to headless everywhere; opt into a visible browser via `ROD_MCP_E2E_HEADED` for local debugging:

```go
if os.Getenv("ROD_MCP_E2E_HEADED") == "" {
    args = append(args, "--headless")
}
```

CI behavior is unchanged (it already ran headless). Since CI runs the full e2e suite headless, every e2e test is proven to pass headless — so defaulting local to headless is safe. Test-harness-only change; no shipped-binary behavior changes.

## Verification

`go build ./...`, `go vet -tags e2e ./e2e/` pass. With the new default (no `CI`, no `ROD_MCP_E2E_HEADED`), the full `TestE2E_Input` suite passes locally with **0 Chrome crashes**.
