### PR TITLE
fix: guard EnsurePage against nil page so rod_navigate returns a clear error instead of panicking

### DIFF
--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/charmbracelet/log"
@@ -80,6 +81,9 @@ var (
 			page, err := rodCtx.EnsurePage()
 			if err != nil {
 				return toolErr("navigate to "+url, err)
+			}
+			if page == nil {
+				return toolErr("navigate to "+url, errors.New("no active page after EnsurePage"))
 			}
 
 			// Update headers for the target URL (applies domain-specific headers from config)

--- a/types/context.go
+++ b/types/context.go
@@ -95,6 +95,7 @@ type Context struct {
 }
 
 var browserLaunchNow = time.Now
+var createPageFunc = (*Context).createPage
 
 func NewContext(ctx context.Context, cfg Config) *Context {
 	return &Context{
@@ -112,6 +113,9 @@ func (ctx *Context) EnsurePage() (*rod.Page, error) {
 	}
 	ctx.browserLock.Lock()
 	defer ctx.browserLock.Unlock()
+	if ctx.page == nil {
+		return nil, errors.New("failed to create page after browser launch — retry rod_navigate")
+	}
 	return ctx.page, nil
 }
 
@@ -184,7 +188,7 @@ func (ctx *Context) initLocked() (bool, error) {
 			return recovered, err
 		}
 		ctx.startKeepalive()
-		ctx.page, err = ctx.createPage()
+		ctx.page, err = createPageFunc(ctx)
 		if err != nil {
 			pageErr := fmt.Errorf("create initial page: %w", err)
 			log.Warnf("browser launch failed after connect: reason=%s error=%s", launchReason, pageErr)
@@ -201,7 +205,7 @@ func (ctx *Context) initLocked() (bool, error) {
 		return recovered, nil
 	}
 	if ctx.page == nil {
-		ctx.page, err = ctx.createPage()
+		ctx.page, err = createPageFunc(ctx)
 		if err != nil {
 			return recovered, fmt.Errorf("create page: %w", err)
 		}

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -140,6 +140,40 @@ func TestActivePageRequiresExistingPage(t *testing.T) {
 	}
 }
 
+func TestEnsurePageErrorsWhenInitialLeavesPageNil(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx := NewContext(parent, Config{Mode: Text, Headless: true})
+	defer func() {
+		ctx.browserLock.Lock()
+		if ctx.keepaliveCancel != nil {
+			ctx.keepaliveCancel()
+			ctx.keepaliveCancel = nil
+		}
+		ctx.releaseInstanceLockLocked()
+		ctx.browser = nil
+		ctx.browserLock.Unlock()
+	}()
+
+	withLaunchBrowserFunc(t, func(context.Context, Config) (*rod.Browser, string, error) {
+		return rod.New(), "", nil
+	})
+	withCreatePageFunc(t, func(*Context, ...string) (*rod.Page, error) {
+		return nil, nil
+	})
+
+	page, err := ctx.EnsurePage()
+	if err == nil {
+		t.Fatal("EnsurePage: expected error when initial succeeds without creating a page")
+	}
+	if page != nil {
+		t.Fatalf("EnsurePage returned page = %v, want nil", page)
+	}
+	if !strings.Contains(err.Error(), "failed to create page after browser launch") {
+		t.Fatalf("EnsurePage error = %q, want page creation failure message", err.Error())
+	}
+}
+
 func TestLatestSnapshot_ReturnsExisting(t *testing.T) {
 	ctx := newTestContext()
 
@@ -562,6 +596,15 @@ func withLaunchBrowserFunc(t *testing.T, fn func(context.Context, Config) (*rod.
 	launchBrowserFunc = fn
 	t.Cleanup(func() {
 		launchBrowserFunc = prev
+	})
+}
+
+func withCreatePageFunc(t *testing.T, fn func(*Context, ...string) (*rod.Page, error)) {
+	t.Helper()
+	prev := createPageFunc
+	createPageFunc = fn
+	t.Cleanup(func() {
+		createPageFunc = prev
 	})
 }
 


### PR DESCRIPTION
Closes #311.

## Problem
`rod_navigate` panicked with `tool handler panic: runtime error: invalid memory address or nil pointer dereference`. `EnsurePage()` was the only one of the three page accessors (`EnsurePage`/`ControlledPage`/`ActivePage`) missing the `ctx.page == nil` guard, so it could return `(nil, nil)`; `NavigationHandler` then called `page.Timeout(...)` (which does `pageClone := *page`) on a nil `*rod.Page` → panic. Same class as #309 (`rod_set_headers`), never applied to the navigate path.

## Fix
- `types/context.go` — `EnsurePage()` now returns a clear error (`"failed to create page after browser launch — retry rod_navigate"`) when `ctx.page == nil`, mirroring `ControlledPage()`/`ActivePage()`.
- `tools/navigation.go` — defensive nil check after `EnsurePage()` before `page.Timeout(...)`, so a future accessor regression cannot re-introduce the deref.
- `types/context.go` — small `createPageFunc` test seam (matches the existing `browserLaunchNow`/`withLaunchBrowserFunc` seams) enabling a deterministic test of the new guard.
- `types/context_test.go` — `TestEnsurePageErrorsWhenInitialLeavesPageNil`: stubs browser launch + page creation so `initLocked` succeeds without creating a page, and asserts `EnsurePage()` returns a non-nil error (never a nil page).

## Validation
`go build ./...`, `go vet ./...`, and the page-guard tests pass.

## Note (separate, not in this PR)
A Chrome user-data-dir (7,452 files under `types/rod/browser/`) is already committed on `main` — pre-existing repo-hygiene litter unrelated to this fix. Filed separately; intentionally left untouched here to keep this PR focused.