### PR TITLE
fix: don't Close() a never-connected browser on CDP connect failure (rod_navigate panic)

### DIFF
--- a/types/context_browser.go
+++ b/types/context_browser.go
@@ -172,13 +172,13 @@ func configureLauncher(ctx context.Context, cfg Config, userDataDir string) (*la
 
 func controlBrowser(ctx context.Context, controlURL string) (*rod.Browser, error) {
 	browser := rod.New().Context(ctx)
-	err := browser.ControlURL(controlURL).Connect()
-	if err != nil {
-		closeErr := browser.Close()
-		if closeErr != nil {
-			return nil, fmt.Errorf("close browser after connect failure: %w", closeErr)
-		}
-		return nil, fmt.Errorf("connect to browser: %w", err)
+	if err := browser.ControlURL(controlURL).Connect(); err != nil {
+		// Do NOT call browser.Close() here: when Connect() fails (e.g. no
+		// Chrome listening at the configured CDP endpoint), the browser's CDP
+		// client was never established, and go-rod's Close() dereferences that
+		// nil client — turning a clean "can't connect" error into a panic.
+		// There is nothing to close on a browser that never connected.
+		return nil, fmt.Errorf("connect to browser at %s: %w", controlURL, err)
 	}
 	if err := browser.IgnoreCertErrors(true); err != nil {
 		return nil, fmt.Errorf("set ignore certificate errors: %w", err)

--- a/types/context_browser_test.go
+++ b/types/context_browser_test.go
@@ -4,7 +4,33 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestControlBrowserConnectFailureReturnsError locks in the fix for the
+// rod_navigate panic: connecting to a CDP endpoint with no Chrome listening
+// must return a clean error, never panic. Before the fix, controlBrowser
+// called browser.Close() on the connect-failure path, and go-rod's Close()
+// dereferenced the never-established nil CDP client.
+func TestControlBrowserConnectFailureReturnsError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Port 1 has no CDP server; Connect() must fail (connection refused).
+	b, err := controlBrowser(ctx, "ws://127.0.0.1:1")
+	if err == nil {
+		if b != nil {
+			_ = b.Close()
+		}
+		t.Fatal("controlBrowser: expected error connecting to a dead endpoint, got nil")
+	}
+	if b != nil {
+		t.Fatalf("controlBrowser: expected nil browser on connect failure, got %v", b)
+	}
+	if !strings.Contains(err.Error(), "connect to browser") {
+		t.Fatalf("controlBrowser error = %q, want a connect-to-browser wrap", err.Error())
+	}
+}
 
 func TestConfigureLauncherHeadlessFlag(t *testing.T) {
 	l, err := configureLauncher(context.Background(), Config{


### PR DESCRIPTION
Closes #314. Real root cause behind #311's reported `rod_navigate` panic (PR #312 fixed an adjacent latent path but not this one).

## Problem
`controlBrowser` called `browser.Close()` when `ControlURL(...).Connect()` failed. With no Chrome at the configured CDP endpoint (`:9222`), the CDP client was never established and go-rod's `Close()` dereferenced the nil client → panic. Verified live from the rod-mcp log (panic right after "connecting to configured CDP endpoint").

## Fix
- `context_browser.go`: on connect failure, return `connect to browser at <url>: <err>` and do **not** call `Close()` on the never-connected browser.
- `context_browser_test.go`: `TestControlBrowserConnectFailureReturnsError` — connect to a dead endpoint returns an error, never panics.

## Verified live
After deploying, `rod_navigate` returns a clean error instead of panicking:
`launch browser: connect to browser at http://127.0.0.1:9222: dial tcp 127.0.0.1:9222: connect: connection refused`

`go build`, `go vet`, `go test ./types/...` pass.