### PR TITLE
docs+test: public-safe Copilot instructions and stabilize flaky nav e2e

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,71 @@
-See [docs/AGENTS.md](../docs/AGENTS.md) for all project guidelines.
+# Copilot Instructions for rod-mcp
+
+rod-mcp is a Go MCP server that wraps go-rod browser automation and exposes
+browser control tools over stdio. Keep suggestions focused on the public
+repository and avoid private paths, hostnames, credentials, incidents, support
+queues, or agent orchestration process details.
+
+## Repository Context
+
+- Go module: `github.com/aliwatters/rod-mcp`.
+- Runtime: follow `go.mod` for the supported Go version and dependency set.
+- MCP framework: `github.com/mark3labs/mcp-go`.
+- Browser automation: `github.com/go-rod/rod` controlling Chrome or Chromium.
+- Main entry points are `main.go`, `cmd.go`, `server.go`, and `runner.go`.
+- Tool implementations live in `tools/`; shared browser context, config,
+  snapshots, profiles, and embedded JavaScript live in `types/`.
+
+## Build and Verification
+
+Use the same commands CI relies on when relevant:
+
+```bash
+go build -o rod-mcp
+go vet ./...
+go test ./...
+go test -tags e2e -v -timeout 300s ./e2e/
+```
+
+The e2e tests launch a real browser and may need Chrome or Chromium plus system
+libraries. For docs-only changes, prefer lightweight checks such as
+`git diff --check`.
+
+## Code Guidance
+
+- Follow the existing Go style: standard library imports first, then external
+  packages, then internal `github.com/aliwatters/rod-mcp/...` packages.
+- Keep MCP tools in the established pattern: define an `mcp.Tool`, then provide
+  a handler factory that uses `rodCtx.Execute`.
+- Let `Execute` manage snapshot invalidation. Do not call
+  `InvalidateSnapshot` inside tool handlers.
+- Preserve ref continuity for tools that interact with snapshot elements by
+  using `WithSnapshot: true` where the next interaction needs an updated
+  accessibility snapshot.
+- Resolve elements through the existing helper paths: refs first, CSS selectors
+  when supported, and accessible-name matching for semantic targeting.
+- For React-aware filling, keep using the `this` binding pattern expected by
+  rod's `Eval`; do not pass the DOM element as a JavaScript function argument.
+- Wrap errors with useful context and return MCP tool errors through existing
+  helpers such as `toolErr`.
+- Prefer table-driven tests with `t.Run` and focused assertions for tool schema,
+  handler behavior, snapshots, config, and utility functions.
+
+## Generated and Ignored Paths
+
+- Do not review or suggest changes in ignored output such as `rod-mcp`,
+  `vendor/`, `node_modules/`, `build/`, `dist/`, `tmp/`, `temp/`, runtime
+  browser profiles, screenshots, PDFs, logs, or `.ax/`.
+- `types/js/snapshotter.js` is the minified asset used by Go embeds. Its source
+  is `types/js/snapshotter_raw.js`, and the minification command is
+  `npm run dev`.
+- Keep generated, embedded, and minified JavaScript changes paired with their
+  source changes when they are part of a functional update.
+
+## Review Focus
+
+- Check that tool changes preserve text mode and vision mode behavior.
+- Watch for snapshot lifecycle regressions, stale refs, missing DOM-stability
+  waits after mutations, and unnecessary Chrome DevTools Protocol imports.
+- Check browser-profile and cookie handling carefully for data exposure risks.
+- Prefer small, public-safe documentation updates over copying long guidance
+  from `docs/AGENTS.md`.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -18,9 +18,10 @@ import (
 
 // Timeout constants for use across all test groups.
 const (
-	timeoutShort  = 5 * time.Second
-	timeoutMedium = 10 * time.Second
-	timeoutLong   = 30 * time.Second
+	timeoutShort        = 5 * time.Second
+	timeoutMedium       = 10 * time.Second
+	timeoutLong         = 30 * time.Second
+	timeoutColdNavigate = 90 * time.Second
 )
 
 // jsonRPCRequest is a JSON-RPC 2.0 request.
@@ -51,13 +52,14 @@ type mcpResult struct {
 
 // harness manages the rod-mcp subprocess and JSON-RPC communication.
 type harness struct {
-	t       *testing.T
-	cmd     *exec.Cmd
-	stdin   io.WriteCloser
-	scanner *bufio.Scanner
-	lines   <-chan scanLine
-	mu      sync.Mutex
-	nextID  int
+	t         *testing.T
+	cmd       *exec.Cmd
+	stdin     io.WriteCloser
+	scanner   *bufio.Scanner
+	lines     <-chan scanLine
+	mu        sync.Mutex
+	nextID    int
+	navigated bool
 	// responses stores responses by ID for out-of-order reading.
 	responses map[int]jsonRPCResponse
 }
@@ -300,9 +302,19 @@ func truncate(s string, n int) string {
 // Uses a longer timeout to accommodate browser launch on first navigation.
 func (h *harness) navigate(url string) string {
 	h.t.Helper()
-	result := h.callWithTimeout("rod_navigate", map[string]any{"url": url}, timeoutLong)
+	result := h.callWithTimeout("rod_navigate", map[string]any{"url": url}, h.navigateTimeout())
 	h.callWithTimeout("rod_wait_for", map[string]any{"selector": "body", "timeout": 15000}, 20*time.Second)
 	return result
+}
+
+func (h *harness) navigateTimeout() time.Duration {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.navigated {
+		return timeoutLong
+	}
+	h.navigated = true
+	return timeoutColdNavigate
 }
 
 // initialize performs the MCP handshake.
@@ -406,7 +418,7 @@ func TestE2E_Navigation(t *testing.T) {
 
 		result = h.callWithTimeout("rod_navigate", map[string]any{
 			"url": "https://the-internet.herokuapp.com",
-		}, timeoutLong)
+		}, timeoutColdNavigate)
 		assertContains(t, result, "Navigated to")
 	})
 }


### PR DESCRIPTION
Bundle of two related repo-hygiene fixes.

Closes #321
Closes #316

## #321 — public-safe Copilot instructions
Replaces the stub `.github/copilot-instructions.md` with concise, repo-tailored guidance: repository context, real build/verify commands (matching CI: `go build`, `go vet`, `go test`, `go test -tags e2e`), code patterns (MCP tool/handler, snapshot lifecycle, element resolution, smart fill), generated/ignored paths, and review focus.

Redaction audit (public repo): no personal paths, internal hostnames, private repo names, credentials, private incidents, or agent-orchestration internals. Does not duplicate the longer `docs/AGENTS.md`.

## #316 — flaky TestE2E_Navigation cold-start
The first navigate of each e2e harness bundles cold Chrome launch plus the first external-site navigation, intermittently exceeding the 30s response window on cold GitHub-hosted runners.

Adds `timeoutColdNavigate` (90s) applied only to the first navigate per harness (and the post-close relaunch navigate); subsequent navigates keep the tighter 30s `timeoutLong`. Selection is via a mutex-guarded `navigated` flag so only the genuine cold-start gets the extended bounded window.

## Verification
- `go build`, `go vet ./...` — pass (main module)
- `go vet -tags e2e ./...` — pass (e2e module)
- `TestE2E_Navigation` run 3x locally — green every run (17.7s / 13.7s / 13.7s)