### PR TITLE
feat: add visible login workflow (Closes #324)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ Or download a [pre-built binary](https://github.com/aliwatters/rod-mcp/releases)
 }
 ```
 
+**Visible browser for interactive login / 2FA**:
+
+```json
+{
+  "mcpServers": {
+    "rod-mcp-gui": {
+      "command": "rod-mcp",
+      "args": ["--no-banner", "--compact-snapshot"]
+    }
+  }
+}
+```
+
+`rod-mcp-gui` should not pass `--headless`. The browser opens a visible window on the first navigation so you can sign in or complete 2FA, then continue automation in the same session.
+
 **Cursor** (`.cursor/mcp.json`):
 
 ```json
@@ -130,7 +145,7 @@ That's it. Your AI agent can now browse the web.
 | `rod_set_headers` | Set HTTP headers for requests |
 | `rod_resize` | Set viewport size and device emulation |
 | `rod_handle_dialog` | Handle JavaScript dialogs (alert, confirm, prompt) |
-| `rod_configure` | Change headless mode or CDP endpoint at runtime |
+| `rod_configure` | Change headless mode, profile, or CDP endpoint at runtime |
 
 ### Tabs
 
@@ -284,6 +299,20 @@ rod-mcp --chrome-debug-port 9222
    ```
 
    Or use `rod_configure` at runtime to switch to a CDP endpoint.
+
+### Interactive login workflow
+
+Use `rod-mcp-gui` or configure a running server before the next navigation:
+
+```json
+{
+  "headless": false,
+  "user_data_dir": "/Users/alice/.config/rod-mcp/profiles/apple-music",
+  "no_clone": true
+}
+```
+
+Then call `rod_navigate` to open the login page, complete the login or 2FA in the visible Chrome window, and continue using the same MCP session. `no_clone=true` uses the profile directly so the login persists across server restarts; omit it when you only want a temporary cloned profile.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Or download a [pre-built binary](https://github.com/aliwatters/rod-mcp/releases)
   "mcpServers": {
     "rod-mcp-gui": {
       "command": "rod-mcp",
-      "args": ["--no-banner", "--compact-snapshot"]
+      "args": ["--gui", "--no-banner", "--compact-snapshot"]
     }
   }
 }
 ```
 
-`rod-mcp-gui` should not pass `--headless`. The browser opens a visible window on the first navigation so you can sign in or complete 2FA, then continue automation in the same session.
+`rod-mcp-gui` passes `--gui`, which forces `headless=false` even when the default config is absent or still says `headless: true`. The browser opens a visible window on the first navigation so you can sign in or complete 2FA, then continue automation in the same session.
 
 **Cursor** (`.cursor/mcp.json`):
 

--- a/cmd.go
+++ b/cmd.go
@@ -11,6 +11,7 @@ import (
 
 type SubCfg struct {
 	Headless        bool
+	HeadlessSet     bool
 	ConfigPath      string
 	Mode            types.Mode
 	CDPEndpoint     string
@@ -25,6 +26,10 @@ type SubCfg struct {
 }
 
 func RunCmd() (*SubCfg, error) {
+	return parseCommandArgs(os.Args)
+}
+
+func parseCommandArgs(args []string) (*SubCfg, error) {
 	subConfig := SubCfg{}
 	cmd := &cli.App{
 		Name:        "Rod MCP Server",
@@ -72,6 +77,10 @@ func RunCmd() (*SubCfg, error) {
 				Destination: &subConfig.Headless,
 			},
 			&cli.BoolFlag{
+				Name:  "gui",
+				Usage: "force a visible browser window by setting headless=false",
+			},
+			&cli.BoolFlag{
 				Name:    "vision",
 				Aliases: []string{"vs"},
 				Usage:   "use to support vision LLM will load  vision tools",
@@ -87,8 +96,8 @@ func RunCmd() (*SubCfg, error) {
 				Destination: &subConfig.OutputDir,
 			},
 			&cli.BoolFlag{
-				Name:    "omit-images",
-				Usage:   "omit inline base64 image data from screenshot results (saves tokens)",
+				Name:  "omit-images",
+				Usage: "omit inline base64 image data from screenshot results (saves tokens)",
 			},
 			&cli.BoolFlag{
 				Name:   "no-banner",
@@ -96,8 +105,16 @@ func RunCmd() (*SubCfg, error) {
 			},
 		},
 		Action: func(c *cli.Context) error {
-			if c.Bool("headless") {
-				subConfig.Headless = true
+			if c.IsSet("headless") {
+				subConfig.Headless = c.Bool("headless")
+				subConfig.HeadlessSet = true
+			}
+			if c.Bool("gui") {
+				if subConfig.HeadlessSet && subConfig.Headless {
+					return fmt.Errorf("--gui cannot be combined with --headless")
+				}
+				subConfig.Headless = false
+				subConfig.HeadlessSet = true
 			}
 
 			if c.Bool("vision") {
@@ -115,7 +132,7 @@ func RunCmd() (*SubCfg, error) {
 			return nil
 		},
 	}
-	err := cmd.Run(os.Args)
+	err := cmd.Run(args)
 	if err != nil {
 		return nil, fmt.Errorf("run cmd: %w", err)
 	}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/aliwatters/rod-mcp/types"
+)
+
+type registryEntry struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
+func TestApplyOverridesCanForceHeadful(t *testing.T) {
+	cfg := types.DefaultConfig
+	applyOverrides(&cfg, &SubCfg{
+		Headless:    false,
+		HeadlessSet: true,
+	})
+
+	if cfg.Headless {
+		t.Fatal("Headless = true, want false")
+	}
+}
+
+func TestParseCommandArgsGUIForcesHeadful(t *testing.T) {
+	subCfg, err := parseCommandArgs([]string{"rod-mcp", "--gui", "--compact-snapshot"})
+	if err != nil {
+		t.Fatalf("parseCommandArgs: %v", err)
+	}
+	if !subCfg.HeadlessSet {
+		t.Fatal("HeadlessSet = false, want true")
+	}
+	if subCfg.Headless {
+		t.Fatal("Headless = true, want false")
+	}
+
+	cfg := types.DefaultConfig
+	applyOverrides(&cfg, subCfg)
+	if cfg.Headless {
+		t.Fatal("registry-style --gui launch stayed headless")
+	}
+}
+
+func TestParseCommandArgsRejectsConflictingHeadlessAndGUI(t *testing.T) {
+	if _, err := parseCommandArgs([]string{"rod-mcp", "--headless", "--gui"}); err == nil {
+		t.Fatal("parseCommandArgs accepted conflicting --headless and --gui")
+	}
+}
+
+func TestGUIServerRegistryLaunchesHeadful(t *testing.T) {
+	data, err := os.ReadFile("mcp-registry.json")
+	if err != nil {
+		t.Fatalf("read registry: %v", err)
+	}
+	var registry map[string]registryEntry
+	if err := json.Unmarshal(data, &registry); err != nil {
+		t.Fatalf("parse registry: %v", err)
+	}
+	entry, ok := registry["rod-mcp-gui"]
+	if !ok {
+		t.Fatal("registry missing rod-mcp-gui entry")
+	}
+
+	if !containsArg(entry.Args, "--gui") {
+		t.Fatalf("rod-mcp-gui args = %v, want --gui", entry.Args)
+	}
+	if containsArg(entry.Args, "--headless") {
+		t.Fatalf("rod-mcp-gui args = %v, must not include --headless", entry.Args)
+	}
+
+	subCfg, err := parseCommandArgs(append([]string{"rod-mcp"}, entry.Args...))
+	if err != nil {
+		t.Fatalf("parse registry args: %v", err)
+	}
+	cfg := types.DefaultConfig
+	applyOverrides(&cfg, subCfg)
+	if cfg.Headless {
+		t.Fatalf("rod-mcp-gui registry args yielded Headless=true: %v", entry.Args)
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -14,8 +14,8 @@ import (
 // applyOverrides merges CLI flag values from subCfg into cfg,
 // letting explicit CLI flags take precedence over the config file.
 func applyOverrides(cfg *types.Config, subCfg *SubCfg) {
-	if subCfg.Headless {
-		cfg.Headless = true
+	if subCfg.HeadlessSet {
+		cfg.Headless = subCfg.Headless
 	}
 	if subCfg.Mode != "" {
 		cfg.Mode = subCfg.Mode

--- a/mcp-registry.json
+++ b/mcp-registry.json
@@ -8,7 +8,7 @@
   },
   "rod-mcp-gui": {
     "command": "~/.local/libexec/rod-mcp",
-    "args": ["--no-banner", "--compact-snapshot", "--config", "~/.config/rod-mcp/rod-mcp-gui.yaml"],
+    "args": ["--gui", "--no-banner", "--compact-snapshot"],
     "description": "Visible Rod MCP browser for interactive login and 2FA flows. Headful by default; use rod_configure to attach a persistent profile or CDP endpoint.",
     "keywords": ["browser", "gui", "visible", "login", "2fa", "auth", "rod", "navigate"],
     "category": "browser"

--- a/mcp-registry.json
+++ b/mcp-registry.json
@@ -5,5 +5,12 @@
     "description": "Browser automation with Rod: headless, GUI, or authenticated Chrome sessions. Use rod_configure to switch modes.",
     "keywords": ["browser", "headless", "gui", "auth", "scrape", "web", "automation", "rod", "navigate"],
     "category": "browser"
+  },
+  "rod-mcp-gui": {
+    "command": "~/.local/libexec/rod-mcp",
+    "args": ["--no-banner", "--compact-snapshot", "--config", "~/.config/rod-mcp/rod-mcp-gui.yaml"],
+    "description": "Visible Rod MCP browser for interactive login and 2FA flows. Headful by default; use rod_configure to attach a persistent profile or CDP endpoint.",
+    "keywords": ["browser", "gui", "visible", "login", "2fa", "auth", "rod", "navigate"],
+    "category": "browser"
   }
 }

--- a/tools/configure.go
+++ b/tools/configure.go
@@ -17,6 +17,10 @@ var Configure = mcp.NewTool(ConfigureToolKey,
 	mcp.WithDescription("Configure browser settings. If the browser is already running it will be closed and restarted with the new settings on the next tool call."),
 	mcp.WithBoolean("headless", mcp.Description("Run the browser in headless mode (true) or with a visible GUI (false)")),
 	mcp.WithString("cdp_endpoint", mcp.Description("Connect to an existing Chrome instance via CDP endpoint URL (e.g. http://127.0.0.1:9222)")),
+	mcp.WithString("user_data_dir", mcp.Description("Chrome profile directory to clone from, or to use directly with no_clone=true. Set this with headless=false for interactive login flows.")),
+	mcp.WithString("clone_domains", mcp.Description("Comma-separated domains whose cookies should be cloned from user_data_dir. Empty string clears the domain filter.")),
+	mcp.WithBoolean("no_clone", mcp.Description("Use user_data_dir directly instead of cloning it. This preserves login state across sessions but requires Chrome not to be using the same profile.")),
+	mcp.WithBoolean("clone_all", mcp.Description("Clone the full profile instead of cookie-only domain cloning. Slower and copies more sensitive browser data.")),
 	mcp.WithBoolean("stealth", mcp.Description("[EXPERIMENTAL] Enable stealth mode to bypass bot detection. Removes automation indicators, patches navigator.webdriver, injects realistic browser fingerprints, and sets a realistic User-Agent header.")),
 )
 
@@ -26,9 +30,27 @@ var ConfigureHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 
 		headless := getOptionalBoolPtr(args, "headless")
 		cdpEndpoint := getOptionalStringPtr(args, "cdp_endpoint")
+		userDataDir := getOptionalStringPtr(args, "user_data_dir")
+		cloneDomainsArg := getOptionalStringPtr(args, "clone_domains")
+		noClone := getOptionalBoolPtr(args, "no_clone")
+		cloneAll := getOptionalBoolPtr(args, "clone_all")
 		stealth := getOptionalBoolPtr(args, "stealth")
 
-		if err := rodCtx.Reconfigure(headless, cdpEndpoint, stealth); err != nil {
+		var cloneDomains *[]string
+		if cloneDomainsArg != nil {
+			parsed := parseCSV(*cloneDomainsArg)
+			cloneDomains = &parsed
+		}
+
+		if err := rodCtx.Reconfigure(types.ReconfigureOptions{
+			Headless:     headless,
+			CDPEndpoint:  cdpEndpoint,
+			Stealth:      stealth,
+			UserDataDir:  userDataDir,
+			CloneDomains: cloneDomains,
+			NoClone:      noClone,
+			CloneAll:     cloneAll,
+		}); err != nil {
 			return toolErr("configure browser", err)
 		}
 
@@ -43,6 +65,26 @@ var ConfigureHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 				parts = append(parts, fmt.Sprintf("cdp_endpoint=%s", *cdpEndpoint))
 			}
 		}
+		if userDataDir != nil {
+			if *userDataDir == "" {
+				parts = append(parts, "user_data_dir cleared")
+			} else {
+				parts = append(parts, fmt.Sprintf("user_data_dir=%s", *userDataDir))
+			}
+		}
+		if cloneDomainsArg != nil {
+			if *cloneDomainsArg == "" {
+				parts = append(parts, "clone_domains cleared")
+			} else {
+				parts = append(parts, fmt.Sprintf("clone_domains=%s", *cloneDomainsArg))
+			}
+		}
+		if noClone != nil {
+			parts = append(parts, fmt.Sprintf("no_clone=%t", *noClone))
+		}
+		if cloneAll != nil {
+			parts = append(parts, fmt.Sprintf("clone_all=%t", *cloneAll))
+		}
 		if stealth != nil {
 			parts = append(parts, fmt.Sprintf("stealth=%t", *stealth))
 		}
@@ -52,4 +94,18 @@ var ConfigureHandler = func(rodCtx *types.Context) server.ToolHandlerFunc {
 		return mcp.NewToolResultText(fmt.Sprintf("Browser configured: %s. Changes take effect on next browser action.", strings.Join(parts, ", "))), nil
 	}
 	return rodCtx.Execute(handler, types.ToolHandlerCallOpts{WithSnapshot: false})
+}
+
+func parseCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, item := range strings.Split(s, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }

--- a/tools/configure_test.go
+++ b/tools/configure_test.go
@@ -23,15 +23,25 @@ func TestConfigureToolDefinition(t *testing.T) {
 	if _, ok := props["cdp_endpoint"]; !ok {
 		t.Error("Configure tool missing 'cdp_endpoint' property")
 	}
+	if _, ok := props["user_data_dir"]; !ok {
+		t.Error("Configure tool missing 'user_data_dir' property")
+	}
+	if _, ok := props["clone_domains"]; !ok {
+		t.Error("Configure tool missing 'clone_domains' property")
+	}
+	if _, ok := props["no_clone"]; !ok {
+		t.Error("Configure tool missing 'no_clone' property")
+	}
+	if _, ok := props["clone_all"]; !ok {
+		t.Error("Configure tool missing 'clone_all' property")
+	}
 	if _, ok := props["stealth"]; !ok {
 		t.Error("Configure tool missing 'stealth' property")
 	}
 
-	// headless, cdp_endpoint, and stealth should be optional (not required)
+	// All configure fields should be optional.
 	for _, r := range Configure.InputSchema.Required {
-		if r == "headless" || r == "cdp_endpoint" || r == "stealth" {
-			t.Errorf("Configure tool parameter %q should not be required", r)
-		}
+		t.Errorf("Configure tool parameter %q should not be required", r)
 	}
 }
 
@@ -175,6 +185,44 @@ func TestConfigureHandlerStealth(t *testing.T) {
 
 	if !rodCtx.Config().Stealth {
 		t.Error("expected Stealth to be true after reconfigure")
+	}
+}
+
+func TestConfigureHandlerUserDataDir(t *testing.T) {
+	cfg := types.DefaultConfig
+	rodCtx := types.NewContext(context.Background(), cfg)
+	defer rodCtx.Close()
+
+	handler := ConfigureHandler(rodCtx)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"headless":      false,
+		"user_data_dir": "/tmp/chrome-profile",
+		"clone_domains": "example.com, *.example.org",
+		"no_clone":      true,
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if text != "Browser configured: headless=false, user_data_dir=/tmp/chrome-profile, clone_domains=example.com, *.example.org, no_clone=true. Changes take effect on next browser action." {
+		t.Errorf("unexpected result text: %s", text)
+	}
+
+	got := rodCtx.Config()
+	if got.Headless {
+		t.Error("expected Headless to be false")
+	}
+	if got.UserDataDir != "/tmp/chrome-profile" {
+		t.Errorf("UserDataDir = %q, want /tmp/chrome-profile", got.UserDataDir)
+	}
+	if got.NoClone != true {
+		t.Error("expected NoClone to be true")
+	}
+	if len(got.CloneDomains) != 2 || got.CloneDomains[0] != "example.com" || got.CloneDomains[1] != "*.example.org" {
+		t.Errorf("CloneDomains = %#v, want parsed domains", got.CloneDomains)
 	}
 }
 

--- a/types/context.go
+++ b/types/context.go
@@ -774,21 +774,44 @@ func (ctx *Context) UpdateHeadersForURL(url string) error {
 	return nil
 }
 
+// ReconfigureOptions describes runtime browser settings that may be changed
+// before the next browser launch. Nil fields are left unchanged.
+type ReconfigureOptions struct {
+	Headless     *bool
+	CDPEndpoint  *string
+	Stealth      *bool
+	UserDataDir  *string
+	CloneDomains *[]string
+	NoClone      *bool
+	CloneAll     *bool
+}
+
 // Reconfigure updates browser settings and closes any running browser so the
-// next tool call reinitializes with the new configuration.  Pass nil for any
-// field to leave it unchanged.
-func (ctx *Context) Reconfigure(headless *bool, cdpEndpoint *string, stealth *bool) error {
+// next tool call reinitializes with the new configuration.
+func (ctx *Context) Reconfigure(opts ReconfigureOptions) error {
 	ctx.browserLock.Lock()
 	defer ctx.browserLock.Unlock()
 
-	if headless != nil {
-		ctx.config.Headless = *headless
+	if opts.Headless != nil {
+		ctx.config.Headless = *opts.Headless
 	}
-	if cdpEndpoint != nil {
-		ctx.config.CDPEndpoint = *cdpEndpoint
+	if opts.CDPEndpoint != nil {
+		ctx.config.CDPEndpoint = *opts.CDPEndpoint
 	}
-	if stealth != nil {
-		ctx.config.Stealth = *stealth
+	if opts.Stealth != nil {
+		ctx.config.Stealth = *opts.Stealth
+	}
+	if opts.UserDataDir != nil {
+		ctx.config.UserDataDir = *opts.UserDataDir
+	}
+	if opts.CloneDomains != nil {
+		ctx.config.CloneDomains = *opts.CloneDomains
+	}
+	if opts.NoClone != nil {
+		ctx.config.NoClone = *opts.NoClone
+	}
+	if opts.CloneAll != nil {
+		ctx.config.CloneAll = *opts.CloneAll
 	}
 
 	// Close existing browser so the next initial() picks up new config.

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -271,7 +271,11 @@ func TestReconfigure_UpdatesConfig(t *testing.T) {
 	endpoint := "http://localhost:9222"
 
 	stealth := true
-	err := ctx.Reconfigure(&headless, &endpoint, &stealth)
+	err := ctx.Reconfigure(ReconfigureOptions{
+		Headless:    &headless,
+		CDPEndpoint: &endpoint,
+		Stealth:     &stealth,
+	})
 	if err != nil {
 		t.Fatalf("Reconfigure: unexpected error: %v", err)
 	}
@@ -287,12 +291,43 @@ func TestReconfigure_UpdatesConfig(t *testing.T) {
 	}
 }
 
+func TestReconfigure_UpdatesProfileSettings(t *testing.T) {
+	ctx := newTestContext()
+	userDataDir := "/tmp/chrome-profile"
+	cloneDomains := []string{"example.com"}
+	noClone := true
+	cloneAll := false
+
+	err := ctx.Reconfigure(ReconfigureOptions{
+		UserDataDir:  &userDataDir,
+		CloneDomains: &cloneDomains,
+		NoClone:      &noClone,
+		CloneAll:     &cloneAll,
+	})
+	if err != nil {
+		t.Fatalf("Reconfigure: unexpected error: %v", err)
+	}
+
+	if ctx.config.UserDataDir != userDataDir {
+		t.Errorf("Reconfigure: UserDataDir = %q, want %q", ctx.config.UserDataDir, userDataDir)
+	}
+	if len(ctx.config.CloneDomains) != 1 || ctx.config.CloneDomains[0] != "example.com" {
+		t.Errorf("Reconfigure: CloneDomains = %#v, want [example.com]", ctx.config.CloneDomains)
+	}
+	if ctx.config.NoClone != true {
+		t.Error("Reconfigure: NoClone should be true")
+	}
+	if ctx.config.CloneAll != false {
+		t.Error("Reconfigure: CloneAll should be false")
+	}
+}
+
 func TestReconfigure_NilFields_NoChange(t *testing.T) {
 	ctx := newTestContext()
 	ctx.config.Headless = true
 	ctx.config.CDPEndpoint = "http://existing"
 
-	err := ctx.Reconfigure(nil, nil, nil)
+	err := ctx.Reconfigure(ReconfigureOptions{})
 	if err != nil {
 		t.Fatalf("Reconfigure(nil, nil, nil): unexpected error: %v", err)
 	}
@@ -704,7 +739,7 @@ func TestReconfigure_Stealth(t *testing.T) {
 	ctx.config.Stealth = false
 
 	stealth := true
-	err := ctx.Reconfigure(nil, nil, &stealth)
+	err := ctx.Reconfigure(ReconfigureOptions{Stealth: &stealth})
 	if err != nil {
 		t.Fatalf("Reconfigure stealth: unexpected error: %v", err)
 	}
@@ -713,7 +748,7 @@ func TestReconfigure_Stealth(t *testing.T) {
 	}
 
 	stealth = false
-	err = ctx.Reconfigure(nil, nil, &stealth)
+	err = ctx.Reconfigure(ReconfigureOptions{Stealth: &stealth})
 	if err != nil {
 		t.Fatalf("Reconfigure stealth=false: unexpected error: %v", err)
 	}


### PR DESCRIPTION
Closes aliwatters/rod-mcp#324

## Summary
- add a headful `rod-mcp-gui` registry entry without `--headless`
- let `rod_configure` set visible mode plus persistent profile options at runtime
- document the interactive login / 2FA workflow

## Test plan
- [x] go test ./tools ./types
- [x] go test ./...
- [x] ax checkin

## Gate status
- [ ] Claude deep-review / cross-vendor review pending
