### PR TITLE
feat: add ROD_MCP_GUI env to force a visible browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Or download a [pre-built binary](https://github.com/aliwatters/rod-mcp/releases)
 
 `rod-mcp-gui` passes `--gui`, which forces `headless=false` even when the default config is absent or still says `headless: true`. The browser opens a visible window on the first navigation so you can sign in or complete 2FA, then continue automation in the same session.
 
+To keep a headless MCP launch config and still open a window, set `ROD_MCP_GUI=1` in the parent agent environment. The server inherits it and treats it like `--gui`, including when `args` already contain `--headless`.
+
 **Cursor** (`.cursor/mcp.json`):
 
 ```json
@@ -209,6 +211,8 @@ That's it. Your AI agent can now browse the web.
 ```
 --config, -c       Path to config file (default: $XDG_CONFIG_HOME/rod-mcp/rod-mcp.yaml, or ~/.config/rod-mcp/rod-mcp.yaml)
 --headless, -hl    Run browser without GUI
+--gui              Force a visible browser window
+ROD_MCP_GUI=1      Same as --gui; overrides --headless (inherited from the parent process)
 --vision, -vs      Enable vision mode (coordinate-based tools)
 --compact-snapshot  Reduce snapshot size for fewer tokens
 --output-dir       Directory for screenshots and PDFs

--- a/cmd.go
+++ b/cmd.go
@@ -9,6 +9,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// guiEnvVar forces a visible browser even when --headless is in the MCP
+// launch args. MCP clients typically inherit this from the parent agent.
+const guiEnvVar = "ROD_MCP_GUI"
+
 type SubCfg struct {
 	Headless        bool
 	HeadlessSet     bool
@@ -78,7 +82,7 @@ func parseCommandArgs(args []string) (*SubCfg, error) {
 			},
 			&cli.BoolFlag{
 				Name:  "gui",
-				Usage: "force a visible browser window by setting headless=false",
+				Usage: "force a visible browser window by setting headless=false (also " + guiEnvVar + "=1; overrides --headless)",
 			},
 			&cli.BoolFlag{
 				Name:    "vision",
@@ -136,7 +140,25 @@ func parseCommandArgs(args []string) (*SubCfg, error) {
 	if err != nil {
 		return nil, fmt.Errorf("run cmd: %w", err)
 	}
+	// Applied after flags so an inherited env can flip a registry-style
+	// `args: ["--headless"]` launch to a visible window.
+	if envForcesHeadful(os.Getenv(guiEnvVar)) {
+		subConfig.Headless = false
+		subConfig.HeadlessSet = true
+	}
 	return &subConfig, nil
+}
+
+// envForcesHeadful reports whether a ROD_MCP_GUI-style value requests a
+// visible browser. Unset, empty, and common falsy values leave other
+// headless sources (flags, yaml, default) alone.
+func envForcesHeadful(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // parseCloneDomains splits a comma-separated domain string into a slice.

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -50,6 +50,66 @@ func TestParseCommandArgsRejectsConflictingHeadlessAndGUI(t *testing.T) {
 	}
 }
 
+func TestParseCommandArgsGUIEnvForcesHeadful(t *testing.T) {
+	t.Setenv(guiEnvVar, "1")
+
+	subCfg, err := parseCommandArgs([]string{"rod-mcp"})
+	if err != nil {
+		t.Fatalf("parseCommandArgs: %v", err)
+	}
+	if !subCfg.HeadlessSet || subCfg.Headless {
+		t.Fatalf("HeadlessSet=%t Headless=%t, want HeadlessSet=true Headless=false", subCfg.HeadlessSet, subCfg.Headless)
+	}
+
+	cfg := types.DefaultConfig
+	applyOverrides(&cfg, subCfg)
+	if cfg.Headless {
+		t.Fatal("ROD_MCP_GUI=1 left DefaultConfig headless")
+	}
+}
+
+func TestParseCommandArgsGUIEnvOverridesHeadlessFlag(t *testing.T) {
+	t.Setenv(guiEnvVar, "true")
+
+	subCfg, err := parseCommandArgs([]string{"rod-mcp", "--headless", "--compact-snapshot"})
+	if err != nil {
+		t.Fatalf("parseCommandArgs: %v", err)
+	}
+
+	cfg := types.DefaultConfig
+	applyOverrides(&cfg, subCfg)
+	if cfg.Headless {
+		t.Fatal("ROD_MCP_GUI=true did not override --headless")
+	}
+}
+
+func TestEnvForcesHeadful(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "1", in: "1", want: true},
+		{name: "true", in: "true", want: true},
+		{name: "TRUE", in: "TRUE", want: true},
+		{name: "yes padded", in: " yes ", want: true},
+		{name: "on", in: "on", want: true},
+		{name: "empty", in: "", want: false},
+		{name: "0", in: "0", want: false},
+		{name: "false", in: "false", want: false},
+		{name: "no", in: "no", want: false},
+		{name: "off", in: "off", want: false},
+		{name: "gui", in: "gui", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := envForcesHeadful(tt.in); got != tt.want {
+				t.Fatalf("envForcesHeadful(%q) = %t, want %t", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGUIServerRegistryLaunchesHeadful(t *testing.T) {
 	data, err := os.ReadFile("mcp-registry.json")
 	if err != nil {

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -138,6 +138,8 @@ compact_snapshot: true
 user_data_dir: ""   # Browser profile directory
 ```
 
+`ROD_MCP_GUI=1` (also `true`/`yes`/`on`) forces a visible window after flags are parsed, so it overrides `--headless` from MCP launch args.
+
 ## Testing
 
 ### Unit Tests


### PR DESCRIPTION
## Summary
- `ROD_MCP_GUI=1` (also `true`/`yes`/`on`) forces a visible Chrome window
- The env is read after CLI flags, so it overrides `--headless` from MCP launch args
- Set it in the parent agent process; the MCP server inherits it

## Test plan
- [x] `go test ./.` (cmd parse + applyOverrides)
- [x] `ROD_MCP_GUI=true` plus `--headless` yields `Headless=false`
- [ ] Restart the MCP server with `ROD_MCP_GUI=1` and confirm a window opens on first navigate